### PR TITLE
fix: ensure multiple revision mode and min replicas for blue/green de…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -146,6 +146,17 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Ensure multiple revision mode
+        run: |
+          az containerapp revision set-mode \
+            --name ${{ env.API_APP_NAME }} \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --mode multiple
+          az containerapp revision set-mode \
+            --name ${{ env.WEB_APP_NAME }} \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --mode multiple
+
       - name: Deploy API staging revision
         id: deploy-api
         run: |
@@ -154,7 +165,8 @@ jobs:
             --name ${{ env.API_APP_NAME }} \
             --resource-group ${{ env.RESOURCE_GROUP }} \
             --image ${{ env.ACR_NAME }}.azurecr.io/codec-api:${{ github.sha }} \
-            --revision-suffix "$SUFFIX"
+            --revision-suffix "$SUFFIX" \
+            --min-replicas 1
           echo "revision=${{ env.API_APP_NAME }}--${SUFFIX}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy Web staging revision
@@ -165,7 +177,8 @@ jobs:
             --name ${{ env.WEB_APP_NAME }} \
             --resource-group ${{ env.RESOURCE_GROUP }} \
             --image ${{ env.ACR_NAME }}.azurecr.io/codec-web:${{ github.sha }} \
-            --revision-suffix "$SUFFIX"
+            --revision-suffix "$SUFFIX" \
+            --min-replicas 1
           echo "revision=${{ env.WEB_APP_NAME }}--${SUFFIX}" >> "$GITHUB_OUTPUT"
 
       - name: Wait for staging revisions to be ready
@@ -179,12 +192,12 @@ jobs:
                 --resource-group ${{ env.RESOURCE_GROUP }} \
                 --revision "$APP_REVISION" \
                 --query properties.runningState -o tsv 2>/dev/null || echo "Unknown")
-              if [ "$STATUS" = "Running" ]; then
-                echo "Revision $APP_REVISION is running"
+              if [ "$STATUS" = "Running" ] || [ "$STATUS" = "Degraded" ]; then
+                echo "Revision $APP_REVISION is running (status: $STATUS)"
                 break
               fi
-              if [ "$STATUS" = "Failed" ]; then
-                echo "Revision $APP_REVISION failed to start"
+              if [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Stopped" ]; then
+                echo "Revision $APP_REVISION failed to start (status: $STATUS)"
                 exit 1
               fi
               if [ "$i" = "30" ]; then

--- a/infra/modules/container-app-web.bicep
+++ b/infra/modules/container-app-web.bicep
@@ -92,7 +92,7 @@ resource webApp 'Microsoft.App/containerApps@2024-03-01' = {
         }
       ]
       scale: {
-        minReplicas: 0
+        minReplicas: 1
         maxReplicas: 2
       }
     }


### PR DESCRIPTION
…ploy

- Add 'Ensure multiple revision mode' step before deploying revisions so CD doesn't depend on a manual infra workflow run
- Set --min-replicas 1 on both containerapp update commands so new revisions with 0% traffic still start at least 1 replica
- Update web Bicep minReplicas from 0 to 1 for consistency
- Handle Degraded and Stopped states in revision readiness polling