### PR TITLE
fix: implement silent token refresh for API client and Google identity

### DIFF
--- a/apps/web/src/lib/services/chat-hub.ts
+++ b/apps/web/src/lib/services/chat-hub.ts
@@ -133,9 +133,9 @@ export class ChatHubService {
 		return this.connection?.state === HubConnectionState.Connected;
 	}
 
-	async start(token: string, callbacks: SignalRCallbacks): Promise<void> {
+	async start(accessTokenFactory: () => string | Promise<string>, callbacks: SignalRCallbacks): Promise<void> {
 		const connection = new HubConnectionBuilder()
-			.withUrl(this.hubUrl, { accessTokenFactory: () => token })
+			.withUrl(this.hubUrl, { accessTokenFactory })
 			.withAutomaticReconnect()
 			.build();
 


### PR DESCRIPTION
## Summary

- **What does this PR change?**
  Adds automatic Google ID token refresh and 401 retry logic so that users who have been idle for more than 1 hour (when the token expires) can continue using the app without needing to manually sign in again.

- **Why is this change needed?**
  Google ID tokens expire after ~1 hour. The app only checked token validity at startup — there was no mechanism to refresh a stale token or handle 401 API responses. After being idle for over an hour, every API call (sending messages, loading channels, etc.) and SignalR reconnections would fail with a 401 Unauthorized error, leaving the user stuck until they refreshed the page.

## Related Issue

No existing issue — discovered via user reports of 401 errors after idle sessions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore

## Testing

- [x] API builds (`dotnet build`)
- [x] Web builds (`npm run build`)
- [x] Svelte checks (`npx svelte-check`)
- [ ] Manual end-to-end check performed

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
- [x] Authz/authn impacts reviewed (if applicable)

## Screenshots / Recordings (if UI changes)

No UI changes — all changes are in auth/network plumbing.

## Notes for Reviewers

Four files changed, all on the web client side (no API changes needed):

- **`lib/auth/google.ts`** — Added `requestFreshToken()` which triggers Google One Tap silent re-authentication. Uses a `pendingRefreshResolver` to intercept the credential callback during programmatic refreshes so it doesn't re-trigger `handleCredential()` / full app re-initialization. Includes a 10-second timeout fallback.

- **`lib/api/client.ts`** — `ApiClient` now accepts an optional `onUnauthorized` callback. Both `request()` and `requestVoid()` intercept 401 responses, invoke the callback to get a fresh token, and retry the request once. If the refresh fails, the original 401 propagates as before.

- **`lib/services/chat-hub.ts`** — `start()` now takes an `accessTokenFactory` function instead of a static token string. This ensures SignalR's `.withAutomaticReconnect()` uses a fresh token on each reconnection attempt, rather than a stale value captured in a closure at startup.

- **`lib/state/app-state.svelte.ts`** — Added `refreshToken()` with deduplication (concurrent callers share a single in-flight refresh). Wires the `onUnauthorized` callback into `ApiClient` and passes a token factory to `ChatHubService` that checks `isTokenExpired()` before returning the current token. On refresh failure, the user is signed out gracefully.