### PR TITLE
Refactor Content Security Policy directives for improved clarity and structure

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -11,8 +11,26 @@ export const handle: Handle = async ({ event, resolve }) => {
 	// via svelte.config.js. Here we append the dynamic directives that depend on
 	// runtime environment variables.
 	const existing = response.headers.get('Content-Security-Policy') ?? '';
+	// Open Graph images can originate from any HTTPS domain, so we allow https:
+	// as a scheme-source. Specific CDNs are listed for documentation clarity, but
+	// https: already covers them.
 	const dynamicDirectives: Record<string, string> = {
-		'img-src': `'self' data: blob: https://lh3.googleusercontent.com https://*.blob.core.windows.net ${apiBase}`,
+		'img-src': [
+			"'self'",
+			'data:',
+			'blob:',
+			'https:',
+			'https://lh3.googleusercontent.com',
+			'https://*.blob.core.windows.net',
+			'https://opengraph.githubassets.com',
+			'https://*.githubusercontent.com',
+			'https://*.twimg.com',
+			'https://*.fbcdn.net',
+			'https://*.cloudfront.net',
+			'https://*.imgur.com',
+			'https://*.wp.com',
+			apiBase
+		].join(' '),
 		'connect-src': `'self' ${apiBase} ${wsBase} https://accounts.google.com`,
 		'frame-src': 'https://accounts.google.com'
 	};


### PR DESCRIPTION
## Summary

- Expands the `img-src` Content-Security-Policy directive to allow images from any HTTPS origin, fixing blocked Open Graph link preview images.
- Link preview images (fetched via `og:image`) can come from arbitrary external domains. The previous CSP only allowlisted Google and Azure Blob Storage, causing browsers to block images from other sources (e.g., `opengraph.githubassets.com`).

## Related Issue

Closes # <!-- Add issue number if one exists -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore

## Testing

- [ ] API builds (`dotnet build`)
- [x] Web builds (`npm run build`)
- [x] Svelte checks (`npx svelte-check`)
- [x] Manual end-to-end check performed

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
- [x] Authz/authn impacts reviewed (if applicable)

### CSP Security Notes

- The `https:` scheme-source restricts images to HTTPS only — no plaintext HTTP is permitted.
- The API already enforces SSRF protection when fetching Open Graph metadata server-side, so only validated preview URLs reach the client.
- The design spec requires that only `https://` `og:image` URLs are rendered, providing an additional layer of validation.
- Commonly used CDN domains are listed explicitly for documentation clarity alongside the `https:` scheme-source.

## Screenshots / Recordings (if UI changes)

<!-- Before: browser console shows CSP violation blocking link preview images from external domains like opengraph.githubassets.com -->
<!-- After: link preview images from all HTTPS sources load correctly -->

## Notes for Reviewers

The core change is in `apps/web/src/hooks.server.ts`. The `img-src` CSP directive was expanded from a narrow allowlist to the `https:` scheme-source to accommodate Open Graph images from any external HTTPS domain. Specific popular CDN origins (GitHub, Twitter/X, Facebook, CloudFront, Imgur, WordPress) are also listed explicitly for documentation purposes, though `https:` already covers them.