### PR TITLE
feat: Implement progressive message loading with cursor-based pagination and scroll position preservation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -536,6 +536,38 @@ Create a Discord-like app called Codec with a SvelteKit web front-end and an ASP
 - [x] Update `README.md` features list
 - [x] Update `PLAN.md` with message editing task breakdown
 
+## Task breakdown: Progressive Message Loading
+
+### API — Cursor-based pagination
+- [x] Add `before` (DateTimeOffset) and `limit` (int) query parameters to `GET /channels/{channelId}/messages`
+- [x] Clamp `limit` to 1–200 range with default of 100
+- [x] Filter messages by `CreatedAt < before` when cursor is provided
+- [x] Fetch `limit + 1` rows to determine `hasMore` flag
+- [x] Return `{ hasMore, messages }` response instead of flat message array
+
+### Web — Types & API client
+- [x] Add `PaginatedMessages` type to `models.ts` (`{ hasMore: boolean; messages: Message[] }`)
+- [x] Export `PaginatedMessages` from barrel index
+- [x] Update `getMessages()` in `ApiClient` to accept optional `{ before?, limit? }` options and return `PaginatedMessages`
+
+### Web — State management
+- [x] Add `hasMoreMessages` and `isLoadingOlderMessages` reactive state fields to `AppState`
+- [x] Update `loadMessages()` to use paginated response and set `hasMoreMessages`
+- [x] Add `loadOlderMessages()` method — uses oldest message timestamp as cursor, prepends results
+- [x] Reset `hasMoreMessages` on sign-out, goHome, kicked, and channel deselection
+
+### Web — Scroll behavior
+- [x] Add `TOP_THRESHOLD` constant (200px) for scroll-near-top detection in `MessageFeed.svelte`
+- [x] Detect scroll near top in `handleScroll()` and trigger older message loading
+- [x] Implement `loadOlderAndPreserveScroll()` — captures `scrollHeight`, loads messages, preserves scroll position via `tick()`
+- [x] Sync `previousMessageCount` after prepending to prevent false unread badge
+- [x] Guard scroll restoration with `isAutoScrolling` flag to prevent re-trigger
+- [x] Add "Loading older messages…" indicator at top of feed
+
+### Verification
+- [x] Backend builds successfully (`dotnet build`, 0 errors)
+- [x] Frontend type-checks with zero errors (`svelte-check`)
+
 ## Next steps
 - Update Google OAuth console: add `https://codec-chat.com` as authorized JavaScript origin
 - Azure Monitor alerts (container restarts, 5xx rate, DB CPU)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The web app runs at `http://localhost:5174` by default.
 - ✅ **Message deletion** — authors can delete their own messages in channels and DMs; cascade-deletes reactions and link previews; real-time removal via SignalR; replies to deleted messages handled gracefully
 - ✅ **Message editing** — authors can edit their own messages in channels and DMs; inline edit mode with Enter to save and Escape to cancel; "(edited)" label on modified messages; real-time sync via SignalR
 - ✅ **Text formatting** — bold (`*text*` or `**text**`) and italic (`_text_`) in messages, with live preview in composer input
+- ✅ **Progressive message loading** — initially loads last 100 messages per channel; older messages load seamlessly as the user scrolls up; cursor-based pagination with scroll position preservation
 - ✅ **Loading screen** — branded full-screen splash with animated progress bar, CRT scanlines, and glowing logo during initial data bootstrap; fades out smoothly once servers, channels, and messages are loaded
 - ✅ **Alpha notification** — on every login, a modal notifies users of the app’s alpha status and links to the GitHub bug report template for easy issue reporting
 

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -2,6 +2,7 @@ import type {
 	MemberServer,
 	Channel,
 	Message,
+	PaginatedMessages,
 	Reaction,
 	Member,
 	UserProfile,
@@ -236,8 +237,13 @@ export class ApiClient {
 
 	/* ───── Messages ───── */
 
-	getMessages(token: string, channelId: string): Promise<Message[]> {
-		return this.request(`${this.baseUrl}/channels/${encodeURIComponent(channelId)}/messages`, {
+	getMessages(token: string, channelId: string, options?: { before?: string; limit?: number }): Promise<PaginatedMessages> {
+		const params = new URLSearchParams();
+		if (options?.before) params.set('before', options.before);
+		if (options?.limit) params.set('limit', String(options.limit));
+		const qs = params.toString();
+		const url = `${this.baseUrl}/channels/${encodeURIComponent(channelId)}/messages${qs ? `?${qs}` : ''}`;
+		return this.request(url, {
 			headers: this.headers(token)
 		});
 	}

--- a/apps/web/src/lib/types/index.ts
+++ b/apps/web/src/lib/types/index.ts
@@ -5,6 +5,7 @@ export type {
 	Mention,
 	ReplyContext,
 	Message,
+	PaginatedMessages,
 	Reaction,
 	Member,
 	UserProfile,

--- a/apps/web/src/lib/types/models.ts
+++ b/apps/web/src/lib/types/models.ts
@@ -62,6 +62,12 @@ export type Message = {
 	replyContext: ReplyContext | null;
 };
 
+/** Paginated message response from the API. */
+export type PaginatedMessages = {
+	hasMore: boolean;
+	messages: Message[];
+};
+
 /** Member of a server. */
 export type Member = {
 	userId: string;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -262,7 +262,7 @@ The `AppState` class in `app-state.svelte.ts` uses Svelte 5 runes (`$state`, `$d
 - `POST /invites/{code}` - Join a server via invite code (any authenticated user; validates expiry and max uses)
 
 #### Messaging
-- `GET /channels/{channelId}/messages` - Get messages in a channel (requires membership; includes `imageUrl`, `replyContext`)
+- `GET /channels/{channelId}/messages?before={timestamp}&limit={n}` - Get messages in a channel with cursor-based pagination (requires membership; `before` DateTimeOffset cursor and `limit` 1–200 default 100; returns `{ hasMore, messages }` with `imageUrl`, `replyContext`)
 - `POST /channels/{channelId}/messages` - Post a message to a channel (requires membership; accepts optional `imageUrl`, `replyToMessageId`; broadcasts via SignalR)
 - `DELETE /channels/{channelId}/messages/{messageId}` - Delete a channel message (author only; cascade-deletes reactions and link previews; broadcasts `MessageDeleted` via SignalR)
 - `POST /channels/{channelId}/messages/{messageId}/reactions` - Toggle an emoji reaction on a message (requires membership; broadcasts via SignalR)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -65,6 +65,7 @@ This document tracks implemented, in-progress, and planned features for Codec.
 - ✅ Message deletion — authors can delete their own messages via action bar; cascade-deletes reactions and link previews; real-time removal via SignalR
 - ✅ Message editing — authors can edit their own messages via inline edit mode; "(edited)" label displayed on modified messages; real-time sync via SignalR
 - ✅ Text formatting — bold (`*text*` or `**text**`) and italic (`_text_`) with live preview in composer
+- ✅ Progressive message loading — initially loads last 100 messages; older messages load seamlessly on scroll-up via cursor-based pagination (`before`/`limit` query params); scroll position preserved during prepend
 
 ### Friends ([detailed spec](FRIENDS.md))
 - ✅ Friend requests (send, accept, decline, cancel)


### PR DESCRIPTION
## Summary

- **What:** Adds progressive (infinite-scroll) message loading to server channels. The API now returns paginated results via cursor-based pagination, and the frontend seamlessly loads older messages as the user scrolls up.
- **Why:** Previously, all messages in a channel were fetched in a single request with no limit. This doesn't scale — channels with thousands of messages would suffer slow load times and high memory usage. Now only the last 100 messages are loaded initially, and older batches are fetched on demand.

### Key changes

**API (`ChannelsController.cs`):**
- `GET /channels/{channelId}/messages` now accepts optional `before` (DateTimeOffset) and `limit` (int, default 100, clamped 1–200) query parameters.
- Uses a `limit + 1` fetch strategy to determine `hasMore` without a separate count query.
- Response shape changed from a flat `Message[]` to `{ hasMore: bool, messages: Message[] }`.

**Frontend types & API client (`models.ts`, `index.ts`, `client.ts`):**
- Added `PaginatedMessages` type (`{ hasMore: boolean; messages: Message[] }`).
- Updated `getMessages()` to accept optional `{ before?, limit? }` options and return `PaginatedMessages`.

**State management (`app-state.svelte.ts`):**
- Added `hasMoreMessages` and `isLoadingOlderMessages` reactive state fields.
- `loadMessages()` now extracts `hasMore` from the paginated response.
- Added `loadOlderMessages()` method — uses the oldest loaded message's `createdAt` as the cursor, prepends results.
- `hasMoreMessages` is reset on sign-out, goHome, kicked, and channel deselection.

**Scroll behavior (`MessageFeed.svelte`):**
- Detects scroll near top (`scrollTop < 200px`) and triggers `loadOlderMessages()`.
- `loadOlderAndPreserveScroll()` captures `scrollHeight` before load, then adjusts `scrollTop` after DOM update via `tick()` to maintain the user's reading position.
- Syncs `previousMessageCount` after prepending to prevent a false "unread messages" badge.
- Guards scroll restoration with `isAutoScrolling` flag to prevent re-triggering the load.
- Displays a "Loading older messages…" indicator at the top of the feed during fetch.

**Documentation (`README.md`, `PLAN.md`, `FEATURES.md`, `ARCHITECTURE.md`):**
- Added progressive message loading to the features list in README and FEATURES.
- Added full task breakdown to PLAN.md.
- Updated the `GET /channels/{channelId}/messages` endpoint documentation in ARCHITECTURE.md to reflect pagination params and response shape.

## Related Issue

N/A — feature implementation

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation update
- [ ] Chore

## Testing

- [x] API builds (`dotnet build`)
- [x] Web builds (`npm run build`)
- [x] Svelte checks (`npx svelte-check`)
- [ ] Manual end-to-end check performed

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
  - `limit` is clamped to 1–200 to prevent abuse
  - `before` is an optional typed `DateTimeOffset` — no injection risk
  - Existing server membership authorization unchanged
- [x] Authz/authn impacts reviewed (if applicable)
  - No changes to authentication or authorization — existing `[Authorize]` and membership checks remain

## Screenshots / Recordings (if UI changes)

<!-- Loading indicator appears at the top of the message feed while fetching older messages. Scroll position is preserved so the user's view doesn't jump. No visible UI change on initial load — only the last 100 messages are shown. -->

## Notes for Reviewers

- **Breaking API change:** The `GET /channels/{channelId}/messages` response is now `{ hasMore, messages }` instead of a flat array. Any external consumers of this endpoint will need to update.
- **Edge case (accepted):** If two messages share an identical `CreatedAt` timestamp at a page boundary, one could theoretically be skipped. This is extremely unlikely given `DateTimeOffset` precision and can be addressed later with an ID-based tiebreaker if needed.
- **DM messages not yet paginated:** The `GET /dm/channels/{channelId}/messages` endpoint already supported `before`/`limit` params. The frontend DM state does not yet use progressive loading — this can be added as a follow-up.

### Files changed

| File | Change |
|------|--------|
| `apps/api/Codec.Api/Controllers/ChannelsController.cs` | Cursor-based pagination on `GetMessages` |
| `apps/web/src/lib/types/models.ts` | Added `PaginatedMessages` type |
| `apps/web/src/lib/types/index.ts` | Barrel export for `PaginatedMessages` |
| `apps/web/src/lib/api/client.ts` | Updated `getMessages()` signature and implementation |
| `apps/web/src/lib/state/app-state.svelte.ts` | Added pagination state and `loadOlderMessages()` |
| `apps/web/src/lib/components/chat/MessageFeed.svelte` | Scroll detection, position preservation, loading indicator |
| `README.md` | Features list update |
| `PLAN.md` | Task breakdown section |
| `docs/FEATURES.md` | Feature listing |
| `docs/ARCHITECTURE.md` | Endpoint documentation |
