### PR TITLE
feat: enhance connection status awareness with auto-refresh on persis…

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -57,7 +57,7 @@ Create a Discord-like app called Codec with a SvelteKit web front-end and an ASP
 - User profile writes optimized — skips `SaveChangesAsync` when Google profile fields unchanged
 - Mention parsing cached per message batch to eliminate redundant regex execution
 - DM messages endpoint returns paginated `{ hasMore, messages }` response (matching channel pagination)
-- Connection status awareness — composer disables with "Codec connecting..." when SignalR disconnects; restores on reconnect
+- Connection status awareness — composer disables with "Codec connecting..." when SignalR disconnects; restores on reconnect; auto-refreshes the page on persistent WebSocket failure
 - SignalR reconnection lifecycle tracked via `isHubConnected` reactive state
 - Both apps containerized with optimized multi-stage Dockerfiles
 - Infrastructure as Code via Bicep modules under `infra/`
@@ -629,6 +629,8 @@ Create a Discord-like app called Codec with a SvelteKit web front-end and an ASP
 - [x] Add `isHubConnected = $state(false)` reactive field to `AppState`
 - [x] Set `isHubConnected` to `true` after successful `hub.start()` and on `onReconnected`
 - [x] Set `isHubConnected` to `false` on `signOut()`, `onReconnecting`, and `onClose`
+- [x] Auto-refresh page via `window.location.reload()` if WebSocket cannot reconnect within 5 seconds (reconnect timer in `onReconnecting`, cleared in `onReconnected`)
+- [x] Immediate page refresh on `onClose` with error (e.g. WebSocket status code 1006)
 
 ### Web — Composer disconnected state
 - [x] Update `Composer.svelte` — when `!app.isHubConnected`, show "Codec connecting..." with animated CSS ellipsis instead of composer input

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The web app runs at `http://localhost:5174` by default.
 - ✅ **Message editing** — authors can edit their own messages in channels and DMs; inline edit mode with Enter to save and Escape to cancel; "(edited)" label on modified messages; real-time sync via SignalR
 - ✅ **Text formatting** — bold (`*text*` or `**text**`) and italic (`_text_`) in messages, with live preview in composer input
 - ✅ **Progressive message loading** — initially loads last 100 messages per channel and DM; older messages load seamlessly as the user scrolls up; cursor-based pagination with `hasMore` flag and scroll position preservation
-- ✅ **Connection status awareness** — composer shows "Codec connecting..." with animated ellipsis when the SignalR connection is lost; automatically restores full input when reconnected
+- ✅ **Connection status awareness** — composer shows "Codec connecting..." with animated ellipsis when the SignalR connection is lost; automatically restores full input when reconnected; auto-refreshes the page if the WebSocket cannot reconnect within 5 seconds
 - ✅ **Response compression** — API responses compressed with Brotli and Gzip for faster load times
 - ✅ **Loading screen** — branded full-screen splash with animated progress bar, CRT scanlines, and glowing logo during initial data bootstrap; fades out smoothly once servers, channels, and messages are loaded
 - ✅ **Alpha notification** — on every login, a modal notifies users of the app’s alpha status and links to the GitHub bug report template for easy issue reporting

--- a/apps/web/src/lib/components/chat/ChatArea.svelte
+++ b/apps/web/src/lib/components/chat/ChatArea.svelte
@@ -134,6 +134,8 @@
 
 	.channel-hash {
 		flex-shrink: 0;
+		width: 24px;
+		height: 24px;
 		color: var(--text-muted);
 		opacity: 0.7;
 	}

--- a/apps/web/src/lib/components/chat/MessageFeed.svelte
+++ b/apps/web/src/lib/components/chat/MessageFeed.svelte
@@ -122,8 +122,20 @@
 	$effect(() => {
 		const count = app.messages.length;
 		const loading = app.isLoadingMessages;
+		const loadingOlder = app.isLoadingOlderMessages;
 
-		if (loading || count === 0) {
+		// While messages are being fetched, the array still holds stale data from
+		// the previous channel. Don't sync previousMessageCount here — the reset
+		// effect already set it to 0 for the new channel.
+		if (loading) return;
+
+		if (count === 0) {
+			previousMessageCount = 0;
+			return;
+		}
+
+		// Older messages were prepended — sync the count without treating them as new
+		if (loadingOlder) {
 			previousMessageCount = count;
 			return;
 		}

--- a/apps/web/src/lib/components/dm/DmChatArea.svelte
+++ b/apps/web/src/lib/components/dm/DmChatArea.svelte
@@ -133,8 +133,13 @@
 		const count = app.dmMessages.length;
 		const loading = app.isLoadingDmMessages;
 
-		if (loading || count === 0) {
-			previousMessageCount = count;
+		// While messages are being fetched, the array still holds stale data from
+		// the previous conversation. Don't sync previousMessageCount here — the
+		// reset effect already set it to 0 for the new conversation.
+		if (loading) return;
+
+		if (count === 0) {
+			previousMessageCount = 0;
 			return;
 		}
 

--- a/apps/web/src/lib/services/chat-hub.ts
+++ b/apps/web/src/lib/services/chat-hub.ts
@@ -141,7 +141,7 @@ export type SignalRCallbacks = {
 	onChannelDeleted?: (event: ChannelDeletedEvent) => void;
 	onReconnecting?: () => void;
 	onReconnected?: () => void;
-	onClose?: () => void;
+	onClose?: (error?: Error) => void;
 };
 
 /**
@@ -245,7 +245,7 @@ export class ChatHubService {
 			connection.onreconnected(callbacks.onReconnected);
 		}
 		if (callbacks.onClose) {
-			connection.onclose(callbacks.onClose);
+			connection.onclose((error) => callbacks.onClose!(error));
 		}
 
 		try {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -165,6 +165,7 @@ The `AppState` class in `app-state.svelte.ts` uses Svelte 5 runes (`$state`, `$d
   - DM typing indicators (`DmTyping` / `DmStoppedTyping` events)
   - Friend-related event delivery (request received/accepted/declined/cancelled, friend removed)
   - Automatic reconnect via `withAutomaticReconnect()`
+  - Auto-refresh fallback — page reloads if reconnection fails within 5 seconds or WebSocket closes with an error
 
 ### Data Layer
 - **ORM:** Entity Framework Core 10
@@ -661,7 +662,7 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for full deployment instructions, rollback pr
 - Tree-shaking and code splitting
 - SignalR for real-time message delivery and typing indicators (eliminates polling)
 - Channel-scoped SignalR groups (targeted broadcasts, not global fan-out)
-- Connection status awareness — composer disables with "Codec connecting..." when SignalR disconnects, preventing failed sends
+- Connection status awareness — composer disables with "Codec connecting..." when SignalR disconnects, preventing failed sends; auto-refreshes on persistent failure
 
 ### Future Improvements
 - Response caching

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -176,6 +176,7 @@ This document tracks implemented, in-progress, and planned features for Codec.
 - ✅ `isHubConnected` reactive state in `AppState` — tracks real-time connection health
 - ✅ Composer disconnected state — shows "Codec connecting..." with animated ellipsis when SignalR is not connected (both server channels and DMs)
 - ✅ Automatic restoration of full composer input on reconnection
+- ✅ Auto-refresh on persistent disconnect — if SignalR cannot reconnect within 5 seconds, or if the WebSocket closes with an error (e.g. status code 1006), the page refreshes automatically
 
 ### Frontend Architecture
 - ✅ Modular layered architecture (types, API client, auth, services, state, components)


### PR DESCRIPTION
…tent disconnects, fix visual bug in channel header hash, fix scrolling behavior when joining channel or dm

## Summary

This PR addresses several web client bugs and adds a resilience improvement:

1. **Channel hash visual fix** — The `#` icon in the chat header was partially clipped at the top due to the SVG lacking explicit CSS dimensions in the flex layout. Added `width: 24px` and `height: 24px` to `.channel-hash`.

2. **WebSocket auto-refresh on persistent disconnect** — When the SignalR WebSocket disconnects and cannot reconnect within 5 seconds (or closes with an error such as status code 1006), the page now automatically refreshes. This prevents users from being stuck in a broken state with no real-time updates. Intentional disconnects (sign out) do not trigger a refresh.

3. **False unread count in jump-to-bottom badge** — Scrolling up to load older messages (lazy loading in batches of 100) was incorrectly counted as "new" messages by the `$effect` tracking `app.messages.length`. The effect now checks `app.isLoadingOlderMessages` and syncs the count without incrementing the unread badge.

4. **Scroll-to-bottom failure on channel switch** — Switching channels occasionally left the chat not scrolled to the bottom. The auto-scroll `$effect` was overwriting `previousMessageCount` with the stale old-channel count during the loading phase, so when the new messages arrived with a similar count, `newMessages` computed to 0. Fixed by skipping `previousMessageCount` sync while `isLoadingMessages` is true. Same fix applied to the DM chat area.

5. **Documentation updates** — Updated README, PLAN, FEATURES, and ARCHITECTURE docs to reflect the new auto-refresh behavior.

## Related Issue

Closes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation update
- [ ] Chore

## Testing

- [ ] API builds (`dotnet build`)
- [ ] Web builds (`npm run build`)
- [ ] Svelte checks (`npx svelte-check`)
- [x] Manual end-to-end check performed

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
- [x] Authz/authn impacts reviewed (if applicable)

## Screenshots / Recordings (if UI changes)

<!-- Channel hash icon is no longer clipped at the top in the chat header -->

## Notes for Reviewers

- The auto-refresh uses `window.location.reload()` which is intentionally a hard refresh to fully re-establish the SignalR connection and re-bootstrap app state.
- The `onClose` callback signature in `chat-hub.ts` was broadened to `(error?: Error) => void` to distinguish intentional disconnects (no error) from failures (error present). Only failures trigger the refresh.
- The `previousMessageCount` fix in `MessageFeed.svelte` and `DmChatArea.svelte` changes the `loading` branch from `previousMessageCount = count; return;` to just `return;`, relying on the channel-reset effect to correctly initialize it to `0`.