### PR TITLE
fix: increase voice channel icons and member names visibility

### DIFF
--- a/apps/web/src/lib/components/channel-sidebar/ChannelSidebar.svelte
+++ b/apps/web/src/lib/components/channel-sidebar/ChannelSidebar.svelte
@@ -140,13 +140,13 @@
 										}}
 									>
 										{#if member.avatarUrl}
-											<img class="voice-avatar" src={member.avatarUrl} alt="" width="14" height="14" />
+											<img class="voice-avatar" src={member.avatarUrl} alt="" width="20" height="20" />
 										{:else}
 											<span class="voice-avatar-placeholder"></span>
 										{/if}
 										<span class="voice-member-name" class:muted-member={member.isMuted}>{member.displayName}</span>
 										{#if member.isMuted}
-											<svg class="voice-status-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-label="Muted">
+											<svg class="voice-status-icon" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-label="Muted">
 												<path d="M19 11h-1.7c0 .74-.16 1.43-.43 2.05l1.23 1.23c.56-.98.9-2.09.9-3.28zm-4.02.17c0-.06.02-.11.02-.17V5c0-1.66-1.34-3-3-3S9 3.34 9 5v.18l5.98 5.99zM4.27 3L3 4.27l6.01 6.01V11c0 1.66 1.33 3 2.99 3 .22 0 .44-.03.65-.08l1.66 1.66c-.71.33-1.5.52-2.31.52-2.76 0-5.3-2.1-5.3-5.1H5c0 3.41 2.72 6.23 6 6.72V21h2v-3.28c.91-.13 1.77-.45 2.54-.9L19.73 21 21 19.73 4.27 3z"/>
 											</svg>
 										{/if}
@@ -465,41 +465,41 @@
 
 	.voice-members {
 		list-style: none;
-		padding: 2px 0 4px 28px;
+		padding: 2px 0 4px 30px;
 		margin: 0;
 		width: 100%;
 		display: flex;
 		flex-direction: column;
-		gap: 3px;
+		gap: 4px;
 	}
 
 	.voice-member {
 		display: flex;
 		align-items: center;
-		gap: 5px;
+		gap: 6px;
 		touch-action: manipulation;
 		-webkit-touch-callout: none;
 		user-select: none;
 	}
 
 	.voice-avatar {
-		width: 14px;
-		height: 14px;
+		width: 20px;
+		height: 20px;
 		border-radius: 50%;
 		flex-shrink: 0;
 		object-fit: cover;
 	}
 
 	.voice-avatar-placeholder {
-		width: 14px;
-		height: 14px;
+		width: 20px;
+		height: 20px;
 		border-radius: 50%;
 		background: var(--bg-tertiary);
 		flex-shrink: 0;
 	}
 
 	.voice-member-name {
-		font-size: 12px;
+		font-size: 13px;
 		color: var(--text-muted);
 		overflow: hidden;
 		text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

Voice channel member avatars, names, and muted icons were too small (14px, 12px, 12px). Increased them to 20px, 13px, and 14px respectively to improve visibility and match the visual scale of other sidebar elements.

## Changes

- Avatar size: 14px → 20px (matching channel icons)
- Member name font: 12px → 13px (matching other sidebar text)
- Muted icon: 12px → 14px (proportional to avatar)
- Adjusted spacing (gaps and padding) for visual balance

## Testing

- [x] Web builds (`npm run check` — Svelte check: 0 errors)
- [x] Mobile responsiveness verified (240px sidebar width)
- [x] No behavioral changes; pure CSS/sizing

## Type of Change

- [x] Bug fix

## Security Checklist

- [x] No secrets or credentials added
- [x] No input validation changes (styling only)
- [x] No auth changes