### PR TITLE
fix(web): ensure message feed scrolls to bottom on initial load

### DIFF
--- a/apps/web/src/lib/components/chat/MessageFeed.svelte
+++ b/apps/web/src/lib/components/chat/MessageFeed.svelte
@@ -105,6 +105,18 @@
 				requestAnimationFrame(() => scrollToBottom(true));
 			});
 		}
+
+		// Re-scroll when images or embeds finish loading and expand the scroll
+		// height. The 'load' event doesn't bubble, so capture phase is required.
+		function handleContentLoad() {
+			if (isLockedToBottom && !isAtBottom()) {
+				scrollToBottom(true);
+			}
+		}
+		container?.addEventListener('load', handleContentLoad, true);
+		return () => {
+			container?.removeEventListener('load', handleContentLoad, true);
+		};
 	});
 
 	// Reset scroll state on channel change
@@ -147,8 +159,12 @@
 		// Read scroll state without creating a dependency on it
 		untrack(() => {
 			if (isLockedToBottom) {
-				// Use instant scroll for bulk loads (initial load or rapid influx)
-				tick().then(() => scrollToBottom(newMessages > 3));
+				// Use instant scroll for bulk loads (initial load or rapid influx).
+				// Wait for the next animation frame so the browser finishes layout
+				// for the newly rendered messages before we measure scrollHeight.
+				tick().then(() => {
+					requestAnimationFrame(() => scrollToBottom(newMessages > 3));
+				});
 			} else {
 				unreadCount += newMessages;
 			}

--- a/apps/web/src/lib/components/dm/DmChatArea.svelte
+++ b/apps/web/src/lib/components/dm/DmChatArea.svelte
@@ -116,6 +116,18 @@
 				requestAnimationFrame(() => scrollToBottom(true));
 			});
 		}
+
+		// Re-scroll when images or embeds finish loading and expand the scroll
+		// height. The 'load' event doesn't bubble, so capture phase is required.
+		function handleContentLoad() {
+			if (isLockedToBottom && !isAtBottom()) {
+				scrollToBottom(true);
+			}
+		}
+		container?.addEventListener('load', handleContentLoad, true);
+		return () => {
+			container?.removeEventListener('load', handleContentLoad, true);
+		};
 	});
 
 	// Reset scroll on channel change
@@ -150,7 +162,11 @@
 
 		untrack(() => {
 			if (isLockedToBottom) {
-				tick().then(() => scrollToBottom(newMessages > 3));
+				// Wait for the next animation frame so the browser finishes layout
+				// for the newly rendered messages before we measure scrollHeight.
+				tick().then(() => {
+					requestAnimationFrame(() => scrollToBottom(newMessages > 3));
+				});
 			} else {
 				unreadCount += newMessages;
 			}


### PR DESCRIPTION
## Summary
- Add `requestAnimationFrame` to the `$effect` scroll call in both `MessageFeed` and `DmChatArea` so the browser finishes layout before measuring `scrollHeight`
- Add a capture-phase `load` event listener on the scroll container to re-scroll when lazy-loaded images or embeds expand content height while locked to bottom
- Fixes a bug in the deployed environment where the #general channel did not auto-scroll to the bottom after login

## Test plan
- [ ] Login to Codec HQ — #general should auto-scroll to the bottom
- [ ] Switch channels — each channel scrolls to the bottom on load
- [ ] Send a message while at the bottom — auto-scrolls to show it
- [ ] Scroll up, receive a message — "Jump to latest" badge appears, no auto-scroll
- [ ] Load a channel with image attachments — stays at bottom as images load
- [ ] Verify DM conversations also scroll to bottom correctly
- [ ] Purge a channel (admin) then send a message — scrolls correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)