### PR TITLE
Distinguish voice and text channels in Server Settings

### DIFF
--- a/apps/web/src/lib/components/server-settings/ServerSettings.svelte
+++ b/apps/web/src/lib/components/server-settings/ServerSettings.svelte
@@ -79,6 +79,16 @@
 	}
 </script>
 
+{#snippet channelTypeIcon(type: string | undefined)}
+	{#if type === 'voice'}
+		<svg class="channel-icon" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+			<path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02z"/>
+		</svg>
+	{:else}
+		<span class="channel-hash">#</span>
+	{/if}
+{/snippet}
+
 <div class="server-settings">
 	<h1 class="settings-title">Server Settings</h1>
 
@@ -203,18 +213,20 @@
 				<div class="channel-item">
 					{#if channelEditId === channel.id}
 						<div class="inline-edit">
-							<span class="channel-hash">#</span>
-							<input
-								type="text"
-								class="input"
-								bind:value={channelEditName}
-								maxlength="100"
-								disabled={app.isUpdatingChannelName}
-								onkeydown={(e) => {
-									if (e.key === 'Enter') saveChannelName(channel.id);
-									if (e.key === 'Escape') cancelEditingChannel();
-								}}
-							/>
+							<div class="inline-edit-row">
+								{@render channelTypeIcon(channel.type)}
+								<input
+									type="text"
+									class="input"
+									bind:value={channelEditName}
+									maxlength="100"
+									disabled={app.isUpdatingChannelName}
+									onkeydown={(e) => {
+										if (e.key === 'Enter') saveChannelName(channel.id);
+										if (e.key === 'Escape') cancelEditingChannel();
+									}}
+								/>
+							</div>
 							<div class="inline-actions">
 								<button
 									type="button"
@@ -236,7 +248,7 @@
 						</div>
 					{:else}
 						<div class="channel-display">
-							<span class="channel-hash">#</span>
+							{@render channelTypeIcon(channel.type)}
 							<span class="channel-name">{channel.name}</span>
 							{#if app.canManageChannels}
 								<button
@@ -440,6 +452,16 @@
 		gap: 8px;
 	}
 
+	.inline-edit-row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.inline-edit-row .input {
+		flex: 1;
+	}
+
 	.inline-actions {
 		display: flex;
 		gap: 8px;
@@ -524,6 +546,12 @@
 		color: var(--text-muted);
 		font-weight: 600;
 		flex-shrink: 0;
+	}
+
+	.channel-icon {
+		color: var(--text-muted);
+		flex-shrink: 0;
+		opacity: 0.7;
 	}
 
 	.channel-name {


### PR DESCRIPTION
## Summary

- Add visual indicators (speaker icon for voice channels, # hash for text channels) in the server settings channel management page to distinguish channel types
- Extract channel type icon into a reusable Svelte 5 snippet to eliminate duplication
- Fix edit-mode layout so the icon sits beside the input field, matching the display-mode layout
- Add opacity to channel icons to match the visual weight used in the sidebar

## Related Issue

Resolves issue where users could not distinguish between voice and text channels on the server manage page.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore

## Testing

- [x] Web builds (`npm run check` – 0 errors, 16 pre-existing warnings)
- [x] Manual verification of icon rendering in both edit and display modes
- [x] Verified consistency with ChannelSidebar.svelte SVG paths
- [x] Merged latest main with no conflicts or design divergence

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] No new endpoints or input handling changes
- [x] No authz/authn impacts

## Notes for Reviewers

The solution mirrors the existing pattern already used in ChannelSidebar.svelte, ensuring visual consistency across the app. The `{#snippet}` approach follows Svelte 5 conventions and eliminates the need to maintain the SVG markup in two places.