### PR TITLE
fix: enable reaction hover popover on desktop

### DIFF
--- a/apps/web/src/lib/components/chat/ReactionBar.svelte
+++ b/apps/web/src/lib/components/chat/ReactionBar.svelte
@@ -261,4 +261,10 @@
 		inset: 0;
 		z-index: 99;
 	}
+
+	@media (hover: hover) {
+		.popover-backdrop {
+			pointer-events: none;
+		}
+	}
 </style>


### PR DESCRIPTION
## Summary

Fixed a bug where hovering over reaction pills didn't display the reactor user list popover. The popover backdrop was intercepting mouse events on desktop, triggering mouseleave and creating a flicker loop.

Added `@media (hover: hover)` to disable pointer-events on the backdrop for hover-capable devices, while preserving tap-to-dismiss on touch-only devices.

## Type of Change

- [x] Bug fix

## Testing

- [x] Svelte checks pass (0 errors)
- [x] No regressions — touch-dismiss still works on mobile
- [x] Z-index layering verified (popover at 100, backdrop at 99)

## Notes for Reviewers

The fix uses the CSS media query `@media (hover: hover)` to target only devices with hover-capable primary input. This cleanly separates desktop hover behavior (backdrop transparent to pointer events) from mobile touch behavior (backdrop captures taps for dismissal).