### PR TITLE
fix: improve voice controls accessibility and position clamping

### DIFF
--- a/apps/web/src/lib/components/channel-sidebar/ChannelSidebar.svelte
+++ b/apps/web/src/lib/components/channel-sidebar/ChannelSidebar.svelte
@@ -127,6 +127,7 @@
 										class:voice-member--interactive={member.userId !== app.me?.user.id}
 										role={member.userId !== app.me?.user.id ? 'button' : undefined}
 										tabindex={member.userId !== app.me?.user.id ? 0 : undefined}
+										aria-label={member.userId !== app.me?.user.id ? `${member.displayName} volume controls` : undefined}
 										onclick={(e) => {
 											if (member.userId !== app.me?.user.id) {
 												contextMenu = { userId: member.userId, displayName: member.displayName, x: e.clientX, y: e.clientY };

--- a/apps/web/src/lib/components/voice/UserActionSheet.svelte
+++ b/apps/web/src/lib/components/voice/UserActionSheet.svelte
@@ -50,7 +50,7 @@
 
 	// Desktop positioning — clamp to viewport
 	const menuWidth = 220;
-	const menuHeight = 140;
+	const menuHeight = 180;
 	const clampedX = Math.min(x ?? 0, window.innerWidth - menuWidth - 8);
 	const clampedY = Math.min(y ?? 0, window.innerHeight - menuHeight - 8);
 </script>
@@ -67,7 +67,7 @@
 		class:action-sheet--mobile={isMobile}
 		class:action-sheet--desktop={!isMobile}
 		style={!isMobile ? `left: ${clampedX}px; top: ${clampedY}px;` : undefined}
-		role="menu"
+		role="dialog"
 		aria-label="{displayName} volume controls"
 		tabindex="-1"
 		bind:this={sheetEl}
@@ -89,7 +89,7 @@
 			/>
 		</div>
 		{#if sliderValue !== 100}
-			<button class="action-sheet__item" onclick={handleReset} role="menuitem">
+			<button class="action-sheet__item" onclick={handleReset}>
 				Reset Volume
 			</button>
 		{/if}


### PR DESCRIPTION
## Summary
- Add `aria-label` to interactive voice member list items so screen readers announce "Name volume controls"
- Change action sheet `role` from `menu` to `dialog` — a slider is not a valid menu child per WAI-ARIA
- Remove `role="menuitem"` from Reset Volume button (not needed in a dialog)
- Increase menu height estimate from 140px to 180px to prevent viewport overflow when the Reset button is visible

## Test plan
- [ ] Screen reader: focus a voice member → announces "Name volume controls" button
- [ ] Screen reader: open the action sheet → announces as a dialog with label
- [ ] Desktop: click a voice member near the bottom of the viewport → popup stays within bounds
- [ ] Volume slider and Reset button still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)