### PR TITLE
fix: prevent 440hz oscillator from playing on login

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -132,7 +132,9 @@
 
 <ImagePreview />
 <AlphaNotification />
-<IncomingCallOverlay />
+{#if app.incomingCall}
+	<IncomingCallOverlay />
+{/if}
 
 {#if !app.isSignedIn}
 	<LoginScreen />


### PR DESCRIPTION
## Summary

- Fixes a bug where a 440hz oscillator tone plays when users log in for the first time
- Root cause: `IncomingCallOverlay` component was mounted unconditionally, causing its `onMount` hook to start the oscillator immediately
- Solution: Component now only mounts when there is an actual incoming call

## Type of Change

- [x] Bug fix

## Testing

- [x] Web builds (`npm run check` passes with no errors)
- [x] Code reviewed: oscillator lifecycle, initialization flow, no other audio patterns affected
- [x] No desktop client exists that needs parallel fix

## Security Checklist

- [x] No secrets or credentials added
- [x] No authentication/authorization impacts

## Notes for Reviewers

The fix wraps `<IncomingCallOverlay />` in `{#if app.incomingCall}` in `+page.svelte`. This prevents component mounting until there's a real incoming call. The component maintains an inner `{#if app.incomingCall}` guard for TypeScript narrowing (this is defensive and improves template type safety).

The fix is robust—`incomingCall` cannot briefly become truthy during initialization. It only transitions to non-null via SignalR callbacks (real-time call) or call restoration after page refresh (both legitimate scenarios).