### PR TITLE
docs: add roles documentation

### DIFF
--- a/docs/ROLES-DEV.md
+++ b/docs/ROLES-DEV.md
@@ -1,0 +1,82 @@
+# Roles — Developer Reference
+
+See [ROLES.md](ROLES.md) for the user-facing permission matrix.
+
+## Data Model
+
+**`ServerRole` enum** (`apps/api/Codec.Api/Models/ServerRole.cs`):
+
+| Value | Name |
+|---|---|
+| 0 | Owner |
+| 1 | Admin |
+| 2 | Member |
+
+**`ServerMember`** (`apps/api/Codec.Api/Models/ServerMember.cs`) — join table linking users to servers. The `Role` field defaults to `ServerRole.Member`. Primary key is (`ServerId`, `UserId`).
+
+**`User.IsGlobalAdmin`** (`apps/api/Codec.Api/Models/User.cs:28`) — platform-wide admin flag, independent of server membership. Set at startup for the user matching `GlobalAdmin:Email` in config.
+
+## Enforcement Patterns
+
+### Backend (ServersController)
+
+All role-gated endpoints follow this pattern in `apps/api/Codec.Api/Controllers/ServersController.cs`:
+
+1. Check `appUser.IsGlobalAdmin` — if true, skip membership check.
+2. Look up `ServerMember` for the current user and server.
+3. Return `Forbid()` if no membership or insufficient role.
+
+```csharp
+if (!appUser.IsGlobalAdmin)
+{
+    var membership = await db.ServerMembers
+        .FirstOrDefaultAsync(m => m.ServerId == serverId && m.UserId == appUser.Id);
+
+    if (membership is null)
+        return Forbid();
+
+    if (membership.Role is not (ServerRole.Owner or ServerRole.Admin))
+        return Forbid();
+}
+```
+
+**Admin kick restriction:** Admins cannot kick other Admins. The controller checks `callerRole is ServerRole.Admin && targetMembership.Role is ServerRole.Admin` and returns `Forbid()`.
+
+### Frontend (AppState)
+
+`apps/web/src/lib/state/app-state.svelte.ts` (lines 196-220) exposes derived permission flags:
+
+| Property | Allowed Roles |
+|---|---|
+| `canManageChannels` | Owner, Admin, Global Admin |
+| `canKickMembers` | Owner, Admin, Global Admin |
+| `canManageInvites` | Owner, Admin, Global Admin |
+| `canDeleteServer` | Owner, Global Admin |
+| `canDeleteChannel` | Owner, Admin, Global Admin |
+
+Components use these flags to show/hide UI elements (e.g., kick buttons in `MemberItem.svelte`, channel management controls).
+
+### SignalR (ChatHub)
+
+`apps/api/Codec.Api/Hubs/ChatHub.cs` — on connect, Global Admins are automatically added to all server groups so they receive real-time events for every server.
+
+## Key Files
+
+| Area | File |
+|---|---|
+| Role enum | `apps/api/Codec.Api/Models/ServerRole.cs` |
+| Membership model | `apps/api/Codec.Api/Models/ServerMember.cs` |
+| Global admin flag | `apps/api/Codec.Api/Models/User.cs` |
+| Permission checks | `apps/api/Codec.Api/Controllers/ServersController.cs` |
+| Real-time groups | `apps/api/Codec.Api/Hubs/ChatHub.cs` |
+| Seed data | `apps/api/Codec.Api/Data/SeedData.cs` |
+| Frontend state | `apps/web/src/lib/state/app-state.svelte.ts` |
+| Member list UI | `apps/web/src/lib/components/server/MembersSidebar.svelte` |
+| Member item UI | `apps/web/src/lib/components/server/MemberItem.svelte` |
+
+## Adding a New Role-Gated Feature
+
+1. **Backend:** Add a permission check in the relevant controller following the pattern above. Check `IsGlobalAdmin` first, then membership role.
+2. **Frontend state:** Add a `readonly canDoThing = $derived(...)` property in `AppState`.
+3. **Frontend UI:** Gate the UI element with the new derived property.
+4. **Documentation:** Update the permission matrix in `docs/ROLES.md`.

--- a/docs/ROLES.md
+++ b/docs/ROLES.md
@@ -1,0 +1,35 @@
+# Roles
+
+Codec uses a three-tier role system at the server level, plus a platform-wide Global Admin role.
+
+## Permission Matrix
+
+| Capability | Member | Admin | Owner | Global Admin |
+|---|:---:|:---:|:---:|:---:|
+| Send messages | Yes | Yes | Yes | Yes |
+| React to messages | Yes | Yes | Yes | Yes |
+| Create channels | — | Yes | Yes | Yes |
+| Edit/delete channels | — | Yes | Yes | Yes |
+| Create/revoke invites | — | Yes | Yes | Yes |
+| Kick members | — | Members only | All except self | Yes |
+| Update server name | — | Yes | Yes | Yes |
+| Upload/delete server icon | — | Yes | Yes | Yes |
+| Delete server | — | — | Yes | Yes |
+
+## Roles
+
+### Member
+
+The default role assigned when a user joins a server via an invite link. Members can send messages, react to messages, and read channel history.
+
+### Admin
+
+Admins have full management access to a server's channels and invites, and can kick Members. Admins cannot kick other Admins or the Owner. Only the server Owner can promote a member to Admin.
+
+### Owner
+
+The user who created the server. Owners have all Admin permissions plus the ability to delete the server and manage Admins. There is exactly one Owner per server.
+
+### Global Admin
+
+A platform-wide role set via the `GlobalAdmin:Email` configuration value. Global Admins can see and manage all servers regardless of membership, and can delete any server, channel, or message. This role is independent of server-level roles.


### PR DESCRIPTION
## Summary

- Added `docs/ROLES.md`: permission matrix and role descriptions for end users
- Added `docs/ROLES-DEV.md`: data model, enforcement patterns, frontend state, and implementation guide for developers

This documents the existing three-tier server role system (Member, Admin, Owner) plus the platform-wide Global Admin role. No code changes.

## Type of Change

- [x] Documentation update

## Notes for Reviewers

The permission matrix in ROLES.md covers all role-gated capabilities. ROLES-DEV.md includes a checklist for adding new role-gated features and references to all relevant source files.