### PR TITLE
fix(web): style voice call events on mobile

### DIFF
--- a/apps/web/src/lib/components/dm/DmChatArea.svelte
+++ b/apps/web/src/lib/components/dm/DmChatArea.svelte
@@ -1302,6 +1302,14 @@
 	/* ───── Mobile adjustments ───── */
 
 	@media (max-width: 768px) {
+		.system-message.voice-call-event {
+			background: var(--bg-secondary);
+			border-radius: 8px;
+			margin: 4px 16px;
+			padding: 10px 16px;
+			font-size: 14px;
+		}
+
 		.dm-action-btn {
 			min-width: 44px;
 			min-height: 44px;


### PR DESCRIPTION
## Summary

- Adds mobile-specific styling for voice call event system messages in DM channels
- Ensures proper appearance on viewports ≤768px with appropriate background, spacing, and font sizing

## Type of Change

- [x] Bug fix

## Testing

- [x] Web builds (`npm run build`)
- [x] Svelte checks (`npm run check`)
- [x] Manual verification of CSS rule on existing `.system-message.voice-call-event` element

## Security Checklist

- [x] No secrets or credentials added

## Notes for Reviewers

CSS-only change targeting mobile voice call event styling. Uses existing design token `var(--bg-secondary)`.