### PR TITLE
fix(web): remove overflow clipping on DM message action buttons

### DIFF
--- a/apps/web/src/lib/components/dm/DmChatArea.svelte
+++ b/apps/web/src/lib/components/dm/DmChatArea.svelte
@@ -756,7 +756,6 @@
 		grid-template-columns: 56px 1fr;
 		padding: 2px 16px;
 		transition: background-color 150ms ease;
-		contain: content;
 	}
 
 	.message:hover { background: var(--bg-message-hover); }


### PR DESCRIPTION
## Summary

- Fixes reaction and edit buttons being half cut off in DM chat windows
- The `.message` element in DmChatArea used `contain: content`, a CSS containment property that clips absolutely-positioned children extending outside the element's bounds
- The action buttons are positioned at `top: -14px` (above the message) and were being clipped as a result

## Type of Change

- [x] Bug fix

## Testing

- [x] Web builds (`npm run build`)
- [x] Svelte checks (`npx svelte-check`) — 0 errors, 16 warnings (pre-existing)

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] No new input handling or endpoints
- [x] No authz/authn impacts

## Notes for Reviewers

The fix is minimal: removing `contain: content` from the `.message` CSS selector. This property was creating overflow clipping for the absolutely-positioned action buttons. The channel message component (`MessageItem.svelte`) doesn't use this property, which is why the issue only affected DMs.