### PR TITLE
fix(web): flip message actions when near viewport top

### DIFF
--- a/apps/web/src/lib/components/chat/EmojiPicker.svelte
+++ b/apps/web/src/lib/components/chat/EmojiPicker.svelte
@@ -22,12 +22,14 @@
 	let searchInput = $state<HTMLInputElement>();
 	let containerEl = $state<HTMLDivElement>();
 
-	const dynamicMaxHeight = $derived.by(() => {
+	/** Compute max-height based on available viewport space below the picker.
+	 *  Called once at render — not reactive to scroll/resize (by design). */
+	function getMaxHeight(): string {
 		if (!flipped || !containerEl) return '420px';
 		const rect = containerEl.getBoundingClientRect();
 		const available = window.innerHeight - rect.top - 16;
 		return `${Math.min(420, Math.max(200, available))}px`;
-	});
+	}
 
 	const frequentEmojis = getFrequentEmojis(16);
 
@@ -111,7 +113,7 @@
 	bind:this={containerEl}
 	class="emoji-picker-container"
 	class:flipped
-	style:max-height={flipped ? dynamicMaxHeight : undefined}
+	style:max-height={flipped ? getMaxHeight() : undefined}
 	role="dialog"
 	aria-label="Emoji picker"
 >
@@ -302,11 +304,6 @@
 			padding-bottom: env(safe-area-inset-bottom);
 			animation: slide-up 200ms ease;
 			z-index: 100;
-		}
-
-		.emoji-picker-container.flipped {
-			top: unset;
-			bottom: 0;
 		}
 
 		.picker-backdrop {

--- a/apps/web/src/lib/components/chat/MessageItem.svelte
+++ b/apps/web/src/lib/components/chat/MessageItem.svelte
@@ -71,6 +71,7 @@
 		const rect = messageEl.getBoundingClientRect();
 		isFlipped = rect.top < FLIP_THRESHOLD_PX;
 	}
+
 	const quickEmojis = getFrequentEmojis(8);
 
 	const CUSTOM_EMOJI_REGEX = /^:([a-zA-Z0-9_]{2,32}):$/;
@@ -153,6 +154,7 @@
 	class:grouped
 	class:mentioned={isMentioned}
 	onmouseenter={checkFlip}
+	onfocusin={checkFlip}
 >
 	<!-- Floating action bar — appears on hover at top-right of message -->
 	<div class="message-actions" class:picker-open={showPicker || showFullPicker} class:flipped={isFlipped}>
@@ -723,10 +725,8 @@
 			animation: slide-up 200ms ease;
 		}
 
-		.message-actions.flipped .emoji-picker {
-			top: unset;
-			bottom: 0;
-		}
+		/* Note: position: fixed on .emoji-picker requires no ancestor has
+		   transform/will-change — currently safe, but fragile if ancestors change. */
 
 		.picker-backdrop {
 			background: rgba(0, 0, 0, 0.5);

--- a/apps/web/src/lib/components/chat/ReactionBar.svelte
+++ b/apps/web/src/lib/components/chat/ReactionBar.svelte
@@ -35,7 +35,7 @@
 		if (hoverTimeout) clearTimeout(hoverTimeout);
 		hoverTimeout = setTimeout(() => {
 			const rect = el.getBoundingClientRect();
-			popoverFlipped = rect.top < 80;
+			popoverFlipped = rect.top < POPOVER_FLIP_THRESHOLD_PX;
 			hoveredEmoji = emoji;
 		}, 250);
 	}
@@ -50,12 +50,15 @@
 	let touchTriggered = $state(false);
 	let popoverFlipped = $state(false);
 
+	/** Popover height (~80px) + buffer to avoid clipping at viewport top */
+	const POPOVER_FLIP_THRESHOLD_PX = 80;
+
 	function handleTouchStart(emoji: string, el: HTMLElement) {
 		touchTriggered = false;
 		touchTimeout = setTimeout(() => {
 			touchTriggered = true;
 			const rect = el.getBoundingClientRect();
-			popoverFlipped = rect.top < 80;
+			popoverFlipped = rect.top < POPOVER_FLIP_THRESHOLD_PX;
 			hoveredEmoji = emoji;
 		}, 500);
 	}


### PR DESCRIPTION
## Summary

- Fixes message action buttons and emoji pickers being clipped by the scroll container when messages are near the top of the viewport
- Implements flip-direction logic: toolbar and pickers render below the message when `getBoundingClientRect().top < threshold`
- Adds mobile bottom sheets for emoji pickers on viewports ≤768px with slide-up animations and safe-area padding
- Reaction popovers also flip independently when near the viewport top

## Related Issue

Closes codechat issues with action overflow on scroll

## Type of Change

- [x] Bug fix

## Testing

- [x] Web builds (`npm run build`)
- [x] Svelte checks (`npm run check`) — 0 errors, 17 pre-existing warnings

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] No new input handling or endpoints

## Notes for Reviewers

Code review addressed: added `onfocusin` handler for mobile/keyboard support, replaced `$derived.by` with plain function for DOM reads, removed dead CSS, extracted magic numbers as constants, added stacking context warning.