### PR TITLE
fix(web): improve emoji picker layout and custom emoji rendering

### DIFF
--- a/apps/web/src/lib/components/chat/EmojiPicker.svelte
+++ b/apps/web/src/lib/components/chat/EmojiPicker.svelte
@@ -44,9 +44,17 @@
 		const query = search.toLowerCase().trim();
 		const cats: DisplayCategory[] = [];
 
+		const customByKey = new Map(customEmojis.map((c) => [`:${c.name}:`, c]));
+
 		// Frequent category
 		if (frequentEmojis.length > 0) {
-			const frequentItems = frequentEmojis.map((e) => ({ emoji: e, name: e, isCustom: false }));
+			const frequentItems = frequentEmojis.map((e) => {
+				const custom = customByKey.get(e);
+				if (custom) {
+					return { emoji: e, name: custom.name, isCustom: true, imageUrl: custom.imageUrl };
+				}
+				return { emoji: e, name: e, isCustom: false };
+			});
 			const filtered = query
 				? frequentItems.filter((item) => item.emoji.includes(query) || item.name.toLowerCase().includes(query))
 				: frequentItems;
@@ -151,7 +159,7 @@
 							onclick={() => handleSelect(item.emoji)}
 						>
 							{#if item.isCustom && item.imageUrl}
-								<img src={item.imageUrl} alt={item.name} width="24" height="24" />
+								<img src={item.imageUrl} alt={item.name} width="20" height="20" />
 							{:else}
 								{item.emoji}
 							{/if}
@@ -192,6 +200,7 @@
 	}
 
 	.picker-search {
+		flex-shrink: 0;
 		padding: 8px;
 		border-bottom: 1px solid var(--border);
 	}
@@ -217,6 +226,7 @@
 	}
 
 	.category-tabs {
+		flex-shrink: 0;
 		display: flex;
 		padding: 4px 8px;
 		gap: 2px;
@@ -277,8 +287,9 @@
 		border: none;
 		border-radius: 4px;
 		cursor: pointer;
-		font-size: 22px;
+		font-size: 20px;
 		line-height: 1;
+		padding: 0;
 		transition: background 0.12s;
 	}
 
@@ -287,8 +298,8 @@
 	}
 
 	.emoji-btn img {
-		width: 24px;
-		height: 24px;
+		width: 20px;
+		height: 20px;
 		object-fit: contain;
 	}
 


### PR DESCRIPTION
## Summary

- Prevent category tabs and search bar from being squeezed by adding `flex-shrink: 0` to the flex container
- Fix frequent emojis to correctly detect and render custom emojis as images
- Unify emoji sizing from inconsistent 22px/24px to 20px throughout the picker
- Optimize custom emoji lookup with Map-based key index to avoid O(n*m) scans on every keystroke

## Type of Change

- [x] Bug fix

## Testing

- [x] Web builds (`npm run build`)
- [x] Manual verification of layout, custom emoji rendering, and sizing

## Notes for Reviewers

Addresses three reported issues:
1. Category tabs being cut off at the top
2. Frequent custom emojis not rendering correctly
3. Inconsistent and oversized emoji dimensions