### PR TITLE
fix(web): sync composer overlay on scroll

### DIFF
--- a/apps/web/src/lib/components/chat/Composer.svelte
+++ b/apps/web/src/lib/components/chat/Composer.svelte
@@ -127,7 +127,9 @@
 
 	function syncOverlayScroll(): void {
 		if (overlayEl && inputEl) {
-			overlayEl.scrollLeft = inputEl.scrollLeft;
+			requestAnimationFrame(() => {
+				overlayEl.scrollLeft = inputEl.scrollLeft;
+			});
 		}
 	}
 
@@ -238,6 +240,7 @@
 					disabled={!app.selectedChannelId || app.isSending}
 					oninput={handleInput}
 					onkeydown={handleKeydown}
+					onscroll={syncOverlayScroll}
 					onpaste={handlePaste}
 				/>
 			</div>


### PR DESCRIPTION
## Summary

Fixes composer overlay scroll synchronization by adding an `onscroll` handler to the input element and wrapping the overlay scroll update in `requestAnimationFrame` to avoid layout thrashing.

## Type of Change

- [x] Bug fix