### PR TITLE
style: standardize modal button styling

### DIFF
--- a/apps/web/src/lib/components/server-settings/ServerMembers.svelte
+++ b/apps/web/src/lib/components/server-settings/ServerMembers.svelte
@@ -191,11 +191,11 @@
 
 	.role-btn-promote {
 		background: var(--accent);
-		color: #fff;
+		color: var(--bg-tertiary);
 	}
 
 	.role-btn-promote:hover {
-		filter: brightness(1.1);
+		background: var(--accent-hover);
 	}
 
 	.role-btn-demote {

--- a/apps/web/src/lib/components/settings/AccountSettings.svelte
+++ b/apps/web/src/lib/components/settings/AccountSettings.svelte
@@ -75,7 +75,7 @@
 	}
 
 	.sign-out-btn {
-		padding: 10px 20px;
+		padding: 8px 16px;
 		min-height: 44px;
 		background: var(--danger);
 		color: #fff;

--- a/apps/web/src/lib/components/settings/BugReportModal.svelte
+++ b/apps/web/src/lib/components/settings/BugReportModal.svelte
@@ -220,12 +220,12 @@
 
 	.submit-btn {
 		width: 100%;
-		padding: 10px 16px;
+		padding: 8px 16px;
 		min-height: 44px;
 		background: var(--accent);
 		color: var(--bg-tertiary);
 		border: none;
-		border-radius: 4px;
+		border-radius: 3px;
 		font-size: 0.9rem;
 		font-weight: 600;
 		cursor: pointer;
@@ -260,12 +260,12 @@
 		display: block;
 		width: 100%;
 		margin-top: 12px;
-		padding: 10px 16px;
+		padding: 8px 16px;
 		min-height: 44px;
 		background: transparent;
 		border: 1px solid var(--border);
 		color: var(--text-muted);
-		border-radius: 4px;
+		border-radius: 3px;
 		font-size: 0.85rem;
 		cursor: pointer;
 		transition: border-color 150ms, color 150ms;

--- a/apps/web/src/lib/components/settings/ProfileSettings.svelte
+++ b/apps/web/src/lib/components/settings/ProfileSettings.svelte
@@ -352,7 +352,7 @@
 	}
 
 	.save-btn {
-		padding: 10px 16px;
+		padding: 8px 16px;
 		min-height: 44px;
 		background: var(--accent);
 		color: var(--bg-tertiary);

--- a/apps/web/src/lib/components/settings/VoiceAudioSettings.svelte
+++ b/apps/web/src/lib/components/settings/VoiceAudioSettings.svelte
@@ -154,7 +154,7 @@
 		align-items: flex-start;
 		gap: 10px;
 		padding: 10px 12px;
-		background: var(--bg-secondary, #2f3136);
+		background: var(--bg-secondary);
 		border-radius: 6px;
 		cursor: pointer;
 		transition: background-color 150ms ease;
@@ -166,7 +166,7 @@
 
 	.radio-option input[type='radio'] {
 		margin-top: 3px;
-		accent-color: var(--accent, #5865f2);
+		accent-color: var(--accent);
 	}
 
 	.radio-content {
@@ -196,7 +196,7 @@
 		display: inline-flex;
 		align-items: center;
 		padding: 6px 14px;
-		background: var(--bg-secondary, #2f3136);
+		background: var(--bg-secondary);
 		border: 1px solid var(--border);
 		border-radius: 4px;
 		font-size: 14px;
@@ -208,10 +208,10 @@
 
 	.record-btn {
 		padding: 6px 14px;
-		background: var(--accent, #5865f2);
-		color: #fff;
+		background: var(--accent);
+		color: var(--bg-tertiary);
 		border: none;
-		border-radius: 4px;
+		border-radius: 3px;
 		font-size: 13px;
 		font-weight: 500;
 		cursor: pointer;
@@ -219,7 +219,7 @@
 	}
 
 	.record-btn:hover {
-		background: var(--accent-hover, #4752c4);
+		background: var(--accent-hover);
 	}
 
 	.key-recorder {
@@ -227,8 +227,8 @@
 		align-items: center;
 		justify-content: center;
 		padding: 12px;
-		background: var(--bg-secondary, #2f3136);
-		border: 2px solid var(--accent, #5865f2);
+		background: var(--bg-secondary);
+		border: 2px solid var(--accent);
 		border-radius: 6px;
 		outline: none;
 	}
@@ -236,7 +236,7 @@
 	.recording-text {
 		font-size: 14px;
 		font-weight: 500;
-		color: var(--accent, #5865f2);
+		color: var(--accent);
 		animation: pulse 1.5s ease-in-out infinite;
 	}
 


### PR DESCRIPTION
## Summary

- Normalized button styles across server settings and user settings modals for visual consistency
- Standardized padding, border-radius, text colors, and hover effects for all button categories

## Type of Change

- [x] Refactor

## Testing

- [x] Svelte checks (`npx svelte-check`)

## Notes for Reviewers

All changes are CSS-only affecting 5 component files. Primary buttons now use `8px 16px` padding with `3px` border-radius and dark text on the bright green accent background. Removed Discord-era blue color fallbacks from VoiceAudioSettings and standardized hover behavior to use background color changes instead of `filter: brightness()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)