### PR TITLE
fix: include MessageType in DM message API responses

### DIFF
--- a/apps/api/Codec.Api/Controllers/DmController.cs
+++ b/apps/api/Codec.Api/Controllers/DmController.cs
@@ -233,6 +233,7 @@ public class DmController(CodecDbContext db, IUserService userService, IHubConte
                 m.CreatedAt,
                 m.EditedAt,
                 m.ReplyToDirectMessageId,
+                m.MessageType,
                 AuthorCustomAvatarPath = m.AuthorUser != null ? m.AuthorUser.CustomAvatarPath : null,
                 AuthorGoogleAvatarUrl = m.AuthorUser != null ? m.AuthorUser.AvatarUrl : null
             })
@@ -316,6 +317,7 @@ public class DmController(CodecDbContext db, IUserService userService, IHubConte
             LinkPreviews = linkPreviewLookup.TryGetValue(m.Id, out var previews)
                 ? previews
                 : Array.Empty<LinkPreviewDto>(),
+            MessageType = (int)m.MessageType,
             ReplyContext = m.ReplyToDirectMessageId.HasValue
                 ? replyContextLookup.TryGetValue(m.ReplyToDirectMessageId.Value, out var ctx)
                     ? ctx


### PR DESCRIPTION
## Summary

- Adds `MessageType` field to DM message API responses in both the query projection and response DTO
- Allows the frontend to distinguish between regular messages and voice call notification events for proper styling

## Related Issue

Closes #

## Type of Change

- [x] Bug fix

## Testing

- [x] API builds (`dotnet build`)
- [ ] Web builds (`npm run build`)
- [ ] Svelte checks (`npx svelte-check`)
- [ ] Manual end-to-end check performed

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
- [x] Authz/authn impacts reviewed (if applicable)

## Notes for Reviewers

The `MessageType` enum property on `DirectMessage` was already defined but wasn't being returned to the frontend. This fix ensures the field is projected from the database and included in the API response, enabling the frontend to apply appropriate styling to voice call notification messages.