### PR TITLE
fix: consistent button sizes in server settings

### DIFF
--- a/apps/web/src/lib/components/server-settings/ServerSettings.svelte
+++ b/apps/web/src/lib/components/server-settings/ServerSettings.svelte
@@ -615,12 +615,12 @@
 	}
 
 	.btn-danger-sm {
-		padding: 4px 10px;
+		padding: 6px 12px;
 		background: var(--danger);
 		color: #fff;
 		border: none;
 		border-radius: 3px;
-		font-size: 12px;
+		font-size: 13px;
 		font-weight: 500;
 		cursor: pointer;
 		transition: opacity 150ms ease;
@@ -636,12 +636,12 @@
 	}
 
 	.btn-secondary-sm {
-		padding: 4px 10px;
+		padding: 6px 12px;
 		background: transparent;
 		color: var(--text-normal);
 		border: none;
 		border-radius: 3px;
-		font-size: 12px;
+		font-size: 13px;
 		font-weight: 500;
 		cursor: pointer;
 		transition: color 150ms ease;


### PR DESCRIPTION
## Summary

- Increases `btn-danger-sm` and `btn-secondary-sm` padding and font-size to match `btn-edit` buttons (`6px 12px` / `13px` instead of `4px 10px` / `12px`)
- Fixes visual inconsistency where purge/delete buttons were smaller than edit buttons in the channel list

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore

## Testing

- [ ] API builds (`dotnet build`)
- [x] Web builds (`npm run build`)
- [x] Svelte checks (`npx svelte-check`)
- [ ] Manual end-to-end check performed

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
- [x] Authz/authn impacts reviewed (if applicable)

## Screenshots / Recordings (if UI changes)

<!-- Add screenshots or recordings here -->

## Notes for Reviewers

CSS-only change — just padding and font-size on two button classes.