### PR TITLE
polish: improve search panel UI/UX with consistent spacing and hints

### DIFF
--- a/apps/web/src/lib/components/search/SearchFilterBar.svelte
+++ b/apps/web/src/lib/components/search/SearchFilterBar.svelte
@@ -121,7 +121,8 @@
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
-		padding: 8px 0;
+		padding: 8px 12px;
+		border-bottom: 1px solid var(--border);
 	}
 
 	.filter-row {

--- a/apps/web/src/lib/components/search/SearchPanel.svelte
+++ b/apps/web/src/lib/components/search/SearchPanel.svelte
@@ -91,6 +91,7 @@
 		{:else if noResults}
 			<p class="search-status">No results found.</p>
 		{:else if app.searchResults && app.searchResults.results.length > 0}
+			<p class="results-count">{app.searchResults.totalCount} result{app.searchResults.totalCount === 1 ? '' : 's'}</p>
 			<div class="results-list">
 				{#each app.searchResults.results as result (result.id)}
 					<SearchResultItem {result} query={app.searchQuery} onJump={handleJump} />
@@ -126,6 +127,8 @@
 			{/if}
 		{:else if app.searchQuery.trim().length < 2 && app.searchQuery.length > 0}
 			<p class="search-status">Type at least 2 characters to search.</p>
+		{:else if app.searchQuery.length === 0}
+			<p class="search-status search-hint">Search messages in {isDm ? 'this conversation' : 'this channel'}</p>
 		{/if}
 	</div>
 </aside>
@@ -215,7 +218,7 @@
 	.search-results {
 		flex: 1;
 		overflow-y: auto;
-		padding: 4px 8px;
+		padding: 4px 12px;
 		scrollbar-width: thin;
 		scrollbar-color: var(--border) transparent;
 	}
@@ -226,6 +229,20 @@
 		font-size: 13px;
 		padding: 24px 12px;
 		margin: 0;
+	}
+
+	.search-hint {
+		color: var(--text-dim);
+	}
+
+	.results-count {
+		margin: 0;
+		padding: 6px 0 4px;
+		font-size: 11px;
+		font-weight: 600;
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.02em;
 	}
 
 	.results-list {


### PR DESCRIPTION
## Summary

- Fix search filter bar having no horizontal padding (controls were flush against panel edges)
- Unify horizontal spacing across the search panel to 12px (input, filter bar, results)
- Add visual separator (border-bottom) between filter options and results
- Add empty-state hint text when search input is empty
- Display result count summary above results list with proper alignment
- Code review: all requirements met, passes svelte-check with 0 errors

## Type of Change

- [x] UI/UX improvement
- [ ] Bug fix
- [ ] New feature

## Testing

- [x] Svelte checks pass (`npm run check`)
- [x] No TypeScript errors
- [x] Code review completed (no critical/important issues)

## Security Checklist

- [x] No secrets or credentials added
- [x] No input validation changes

## Notes for Reviewers

Pure CSS and minimal template changes. All horizontal spacing now consistent at 12px, improving visual hierarchy. Filter bar and results area alignment now matches the search input above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)