### PR TITLE
fix(security): remove unsafe-inline from script-src CSP directive

### DIFF
--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -11,7 +11,7 @@ const config = {
 			mode: 'auto',
 			directives: {
 				'default-src': ['self'],
-				'script-src': ['self', 'unsafe-inline', 'strict-dynamic', 'https://accounts.google.com'],
+				'script-src': ['self', 'strict-dynamic', 'https://accounts.google.com'],
 				'style-src': ['self', 'unsafe-inline', 'https://fonts.googleapis.com', 'https://accounts.google.com'],
 				'font-src': ['self', 'https://fonts.gstatic.com'],
 				'connect-src': ['self'],


### PR DESCRIPTION
## Summary

- Removes `'unsafe-inline'` from the `script-src` CSP directive in `svelte.config.js`.
- `strict-dynamic` (CSP Level 3) already causes `unsafe-inline` to be ignored in all modern browsers, so this has zero runtime impact. SvelteKit's `csp.mode: 'auto'` generates nonces for inline scripts. Removing the redundant `unsafe-inline` cleans the policy for security scanners.

## Related Issue

N/A

## Type of Change

- [x] Refactor
- [x] Chore

## Testing

- [x] Web builds (`npm run build`)
- [x] Svelte checks (`npx svelte-check`)
- [ ] Manual end-to-end check performed

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
- [x] Authz/authn impacts reviewed (if applicable)

## Notes for Reviewers

The `style-src` directive intentionally retains `unsafe-inline` — Svelte compiles `style:` directives to inline style attributes at runtime, making removal impractical without a major rewrite. This is widely accepted as lower-risk than script-src unsafe-inline.