### PR TITLE
fix: suppress FedCM console errors from Google Sign-In

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -29,7 +29,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 			'https://avatars.githubusercontent.com',
 			apiBase
 		].join(' '),
-		'connect-src': `'self' ${apiBase} ${wsBase} https://accounts.google.com https://www.google.com https://www.youtube.com https://fonts.googleapis.com https://fonts.gstatic.com https://github.com https://discord.com`,
+		'connect-src': `'self' ${apiBase} ${wsBase} https://accounts.google.com https://www.google.com https://play.google.com https://www.youtube.com https://fonts.googleapis.com https://fonts.gstatic.com https://github.com https://discord.com`,
 		'frame-src': 'https://accounts.google.com https://www.google.com https://www.youtube-nocookie.com https://github.com https://discord.com'
 	};
 

--- a/apps/web/src/lib/auth/google.ts
+++ b/apps/web/src/lib/auth/google.ts
@@ -57,6 +57,7 @@ export function initGoogleIdentity(
 			auto_select: opts?.autoSelect ?? true,
 			ux_mode: useRedirect ? 'redirect' : 'popup',
 			login_uri: loginUri,
+			log_level: 'none',
 			callback: (response: { credential: string }) => {
 				onCredential(response.credential);
 			}
@@ -76,7 +77,7 @@ export function initGoogleIdentity(
 				rendered = true;
 			}
 		}
-		if (rendered) {
+		if (rendered && opts?.autoSelect) {
 			google.accounts.id.prompt();
 		}
 	};


### PR DESCRIPTION
## Summary

- Suppresses noisy FedCM/GSI console errors on codec-chat.com by adding `log_level: 'none'` to Google Identity Services initialization and only triggering the One Tap `prompt()` for returning Google users (`autoSelect: true`).
- Adds `https://play.google.com` to the CSP `connect-src` directive to allow GSI telemetry requests that were previously missing.

## Related Issue

N/A — reported via production console observation

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore

## Testing

- [ ] API builds (`dotnet build`)
- [x] Web builds (`npm run build`)
- [x] Svelte checks (`npx svelte-check`)
- [x] Manual end-to-end check performed

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
- [x] Authz/authn impacts reviewed (if applicable)

## Notes for Reviewers

The `prompt()` change means first-time visitors no longer see the Google One Tap overlay — they use the rendered sign-in button instead. Returning Google users still get One Tap auto-sign-in.