### PR TITLE
feat(web): improve mobile typing UX for emoji and GIF pickers

### DIFF
--- a/apps/web/src/lib/components/chat/Composer.svelte
+++ b/apps/web/src/lib/components/chat/Composer.svelte
@@ -9,6 +9,7 @@
 	import EmojiPicker from './EmojiPicker.svelte';
 	import GifPicker from './GifPicker.svelte';
 	import { recordEmojiUse, getFrequentEmojis } from '$lib/utils/emoji-frequency.js';
+	import { isTouchDevice } from '$lib/utils/dom.js';
 
 	const ui = getUIStore();
 	const servers = getServerStore();
@@ -22,10 +23,6 @@
 	const MAX_LINES = 5;
 	let showPicker = $state(false);
 	let pickerTab = $state<'emoji' | 'gif'>('emoji');
-	let inputFocused = $state(false);
-
-	/** Show quick emoji bar only on coarse-pointer (touch) devices. */
-	const isTouchDevice = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
 	let quickEmojis = $state(getFrequentEmojis(8));
 
 	/* ───── Mention autocomplete state ───── */
@@ -281,19 +278,22 @@
 		<ReplyComposerBar authorName={msgStore.replyingTo.authorName} bodyPreview={msgStore.replyingTo.bodyPreview} onCancel={() => msgStore.cancelReply()} />
 	{/if}
 
-	{#if isTouchDevice && inputFocused && !showPicker && channelStore.selectedChannelId}
+	{#if isTouchDevice && !showPicker && !msgStore.replyingTo && channelStore.selectedChannelId}
 		<div class="quick-emoji-bar" role="toolbar" aria-label="Quick emoji">
 			{#each quickEmojis as emoji (emoji)}
+				{@const customMatch = emoji.startsWith(':') && emoji.endsWith(':')
+					? servers.customEmojis.find((c) => `:${c.name}:` === emoji)
+					: undefined}
 				<button
 					type="button"
 					class="quick-emoji-btn"
-					onmousedown={(e) => { e.preventDefault(); handleEmojiInsert(emoji); }}
-				>{emoji}</button>
+					onclick={() => handleEmojiInsert(emoji)}
+				>{#if customMatch}<img src={customMatch.imageUrl} alt={customMatch.name} width="22" height="22" class="quick-emoji-img" />{:else}{emoji}{/if}</button>
 			{/each}
 			<button
 				type="button"
 				class="quick-emoji-btn quick-emoji-more"
-				onmousedown={(e) => { e.preventDefault(); showPicker = true; pickerTab = 'emoji'; }}
+				onclick={() => { showPicker = true; pickerTab = 'emoji'; }}
 				aria-label="Open emoji picker"
 				title="More emojis"
 			>
@@ -339,8 +339,6 @@
 					onkeydown={handleKeydown}
 					onscroll={syncOverlayScroll}
 					onpaste={handlePaste}
-					onfocus={() => { inputFocused = true; }}
-					onblur={() => { inputFocused = false; }}
 				></textarea>
 			</div>
 			<button
@@ -798,13 +796,14 @@
 		font-size: 14px;
 	}
 
-	/* ───── Quick emoji bar (mobile) ───── */
+	/* ───── Mobile adjustments ───── */
 
 	.quick-emoji-bar {
 		display: none;
 	}
 
 	@media (max-width: 768px) {
+		/* Quick emoji bar */
 		.quick-emoji-bar {
 			display: flex;
 			align-items: center;
@@ -844,11 +843,12 @@
 			color: var(--text-muted);
 			font-size: 16px;
 		}
-	}
 
-	/* ───── Mobile adjustments ───── */
+		.quick-emoji-img {
+			object-fit: contain;
+		}
 
-	@media (max-width: 768px) {
+		/* Composer layout */
 		.composer {
 			padding: 0 16px calc(16px + env(safe-area-inset-bottom, 0));
 		}
@@ -886,7 +886,7 @@
 			right: 0;
 			top: unset;
 			width: 100%;
-			max-height: 55vh;
+			max-height: 60vh;
 			border-radius: 12px 12px 0 0;
 			padding-bottom: env(safe-area-inset-bottom);
 			animation: slide-up 200ms ease;

--- a/apps/web/src/lib/components/chat/Composer.svelte
+++ b/apps/web/src/lib/components/chat/Composer.svelte
@@ -104,10 +104,6 @@
 		});
 	}
 
-	function handleQuickEmoji(emoji: string) {
-		handleEmojiInsert(emoji);
-	}
-
 	function handleGifSelect(gifUrl: string) {
 		showPicker = false;
 		pickerTab = 'emoji';
@@ -291,7 +287,7 @@
 				<button
 					type="button"
 					class="quick-emoji-btn"
-					onmousedown={(e) => { e.preventDefault(); handleQuickEmoji(emoji); }}
+					onmousedown={(e) => { e.preventDefault(); handleEmojiInsert(emoji); }}
 				>{emoji}</button>
 			{/each}
 			<button

--- a/apps/web/src/lib/components/chat/Composer.svelte
+++ b/apps/web/src/lib/components/chat/Composer.svelte
@@ -278,7 +278,7 @@
 		<ReplyComposerBar authorName={msgStore.replyingTo.authorName} bodyPreview={msgStore.replyingTo.bodyPreview} onCancel={() => msgStore.cancelReply()} />
 	{/if}
 
-	{#if isTouchDevice && !showPicker && !msgStore.replyingTo && channelStore.selectedChannelId}
+	{#if isTouchDevice && ui.isHubConnected && !showPicker && !msgStore.replyingTo && channelStore.selectedChannelId}
 		<div class="quick-emoji-bar" role="toolbar" aria-label="Quick emoji">
 			{#each quickEmojis as emoji (emoji)}
 				{@const customMatch = emoji.startsWith(':') && emoji.endsWith(':')

--- a/apps/web/src/lib/components/chat/Composer.svelte
+++ b/apps/web/src/lib/components/chat/Composer.svelte
@@ -8,7 +8,7 @@
 	import ComposerOverlay from './ComposerOverlay.svelte';
 	import EmojiPicker from './EmojiPicker.svelte';
 	import GifPicker from './GifPicker.svelte';
-	import { recordEmojiUse } from '$lib/utils/emoji-frequency.js';
+	import { recordEmojiUse, getFrequentEmojis } from '$lib/utils/emoji-frequency.js';
 
 	const ui = getUIStore();
 	const servers = getServerStore();
@@ -22,6 +22,11 @@
 	const MAX_LINES = 5;
 	let showPicker = $state(false);
 	let pickerTab = $state<'emoji' | 'gif'>('emoji');
+	let inputFocused = $state(false);
+
+	/** Show quick emoji bar only on coarse-pointer (touch) devices. */
+	const isTouchDevice = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
+	let quickEmojis = $state(getFrequentEmojis(8));
 
 	/* ───── Mention autocomplete state ───── */
 	let showMentionPicker = $state(false);
@@ -84,6 +89,7 @@
 
 	function handleEmojiInsert(emoji: string) {
 		recordEmojiUse(emoji);
+		quickEmojis = getFrequentEmojis(8);
 		if (!inputEl) return;
 		const start = inputEl.selectionStart ?? msgStore.messageBody.length;
 		const end = inputEl.selectionEnd ?? start;
@@ -96,6 +102,10 @@
 			inputEl.focus();
 			inputEl.setSelectionRange(newPos, newPos);
 		});
+	}
+
+	function handleQuickEmoji(emoji: string) {
+		handleEmojiInsert(emoji);
 	}
 
 	function handleGifSelect(gifUrl: string) {
@@ -275,6 +285,29 @@
 		<ReplyComposerBar authorName={msgStore.replyingTo.authorName} bodyPreview={msgStore.replyingTo.bodyPreview} onCancel={() => msgStore.cancelReply()} />
 	{/if}
 
+	{#if isTouchDevice && inputFocused && !showPicker && channelStore.selectedChannelId}
+		<div class="quick-emoji-bar" role="toolbar" aria-label="Quick emoji">
+			{#each quickEmojis as emoji (emoji)}
+				<button
+					type="button"
+					class="quick-emoji-btn"
+					onmousedown={(e) => { e.preventDefault(); handleQuickEmoji(emoji); }}
+				>{emoji}</button>
+			{/each}
+			<button
+				type="button"
+				class="quick-emoji-btn quick-emoji-more"
+				onmousedown={(e) => { e.preventDefault(); showPicker = true; pickerTab = 'emoji'; }}
+				aria-label="Open emoji picker"
+				title="More emojis"
+			>
+				<svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+					<path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm0 1a6 6 0 1 1 0 12A6 6 0 0 1 8 2Zm-2.5 4a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5Zm5 0a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5ZM4.5 9.5a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 .383.82A3.98 3.98 0 0 1 8 11.5a3.98 3.98 0 0 1-2.883-1.68A.5.5 0 0 1 5 9.5h-1Z"/>
+				</svg>
+			</button>
+		</div>
+	{/if}
+
 	{#if !ui.isHubConnected}
 		<div class="composer-row">
 			<div class="composer-input-wrapper composer-disconnected">
@@ -310,6 +343,8 @@
 					onkeydown={handleKeydown}
 					onscroll={syncOverlayScroll}
 					onpaste={handlePaste}
+					onfocus={() => { inputFocused = true; }}
+					onblur={() => { inputFocused = false; }}
 				></textarea>
 			</div>
 			<button
@@ -767,6 +802,54 @@
 		font-size: 14px;
 	}
 
+	/* ───── Quick emoji bar (mobile) ───── */
+
+	.quick-emoji-bar {
+		display: none;
+	}
+
+	@media (max-width: 768px) {
+		.quick-emoji-bar {
+			display: flex;
+			align-items: center;
+			gap: 2px;
+			padding: 6px 8px;
+			overflow-x: auto;
+			-webkit-overflow-scrolling: touch;
+			scrollbar-width: none;
+		}
+
+		.quick-emoji-bar::-webkit-scrollbar {
+			display: none;
+		}
+
+		.quick-emoji-btn {
+			flex-shrink: 0;
+			display: grid;
+			place-items: center;
+			width: 40px;
+			height: 36px;
+			background: var(--bg-tertiary);
+			border: 1px solid var(--border);
+			border-radius: 8px;
+			cursor: pointer;
+			font-size: 20px;
+			line-height: 1;
+			padding: 0;
+			transition: background 0.12s, transform 0.1s;
+		}
+
+		.quick-emoji-btn:active {
+			transform: scale(0.92);
+			background: var(--bg-message-hover);
+		}
+
+		.quick-emoji-more {
+			color: var(--text-muted);
+			font-size: 16px;
+		}
+	}
+
 	/* ───── Mobile adjustments ───── */
 
 	@media (max-width: 768px) {
@@ -799,5 +882,33 @@
 			padding: 10px 8px;
 			min-height: 44px;
 		}
+
+		.picker-container {
+			position: fixed;
+			bottom: 0;
+			left: 0;
+			right: 0;
+			top: unset;
+			width: 100%;
+			max-height: 55vh;
+			border-radius: 12px 12px 0 0;
+			padding-bottom: env(safe-area-inset-bottom);
+			animation: slide-up 200ms ease;
+		}
+
+		.picker-backdrop {
+			background: rgba(0, 0, 0, 0.5);
+		}
+
+		.picker-tab {
+			padding: 12px 16px;
+			font-size: 0.95rem;
+			min-height: 44px;
+		}
+	}
+
+	@keyframes slide-up {
+		from { transform: translateY(100%); }
+		to { transform: translateY(0); }
 	}
 </style>

--- a/apps/web/src/lib/components/chat/EmojiPicker.svelte
+++ b/apps/web/src/lib/components/chat/EmojiPicker.svelte
@@ -324,7 +324,7 @@
 	}
 
 	@media (max-width: 768px) {
-		.emoji-picker-container {
+		.emoji-picker-container:not(.embedded) {
 			position: fixed;
 			bottom: 0;
 			left: 0;

--- a/apps/web/src/lib/components/chat/EmojiPicker.svelte
+++ b/apps/web/src/lib/components/chat/EmojiPicker.svelte
@@ -111,8 +111,12 @@
 		el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 	}
 
+	/** Skip auto-focus on touch devices to avoid summoning the virtual keyboard
+	 *  when the user just wants to browse/tap emojis. */
+	const isTouchDevice = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
+
 	$effect(() => {
-		searchInput?.focus();
+		if (!isTouchDevice) searchInput?.focus();
 	});
 </script>
 
@@ -336,6 +340,20 @@
 
 		.picker-backdrop {
 			background: rgba(0, 0, 0, 0.5);
+		}
+
+		.picker-search input {
+			font-size: 16px;
+			padding: 10px 12px;
+			min-height: 44px;
+			box-sizing: border-box;
+		}
+
+		.category-tab {
+			min-width: 44px;
+			min-height: 44px;
+			display: grid;
+			place-items: center;
 		}
 	}
 

--- a/apps/web/src/lib/components/chat/EmojiPicker.svelte
+++ b/apps/web/src/lib/components/chat/EmojiPicker.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { emojiCategories } from '$lib/data/emojis';
 	import { getFrequentEmojis } from '$lib/utils/emoji-frequency';
+	import { isTouchDevice } from '$lib/utils/dom';
 	import type { CustomEmoji } from '$lib/types/models';
 
 	let {
@@ -110,10 +111,6 @@
 		const el = scrollContainer?.querySelector(`[data-category="${id}"]`);
 		el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 	}
-
-	/** Skip auto-focus on touch devices to avoid summoning the virtual keyboard
-	 *  when the user just wants to browse/tap emojis. */
-	const isTouchDevice = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
 
 	$effect(() => {
 		if (!isTouchDevice) searchInput?.focus();

--- a/apps/web/src/lib/components/chat/GifPicker.svelte
+++ b/apps/web/src/lib/components/chat/GifPicker.svelte
@@ -44,9 +44,11 @@
 		onClose();
 	}
 
+	const isTouchDevice = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
+
 	onMount(() => {
 		loadTrending();
-		searchInput?.focus();
+		if (!isTouchDevice) searchInput?.focus();
 	});
 
 	onDestroy(() => clearTimeout(debounceTimer));
@@ -207,5 +209,18 @@
 		-webkit-background-clip: text;
 		-webkit-text-fill-color: transparent;
 		transition: opacity 0.12s;
+	}
+
+	@media (max-width: 768px) {
+		.gif-search input {
+			font-size: 16px;
+			padding: 10px 12px;
+			min-height: 44px;
+			box-sizing: border-box;
+		}
+
+		.gif-item {
+			min-height: 44px;
+		}
 	}
 </style>

--- a/apps/web/src/lib/components/chat/GifPicker.svelte
+++ b/apps/web/src/lib/components/chat/GifPicker.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte';
 	import { searchGifs, getTrendingGifs, type GiphyGif } from '$lib/services/giphy.js';
+	import { isTouchDevice } from '$lib/utils/dom.js';
 
 	let {
 		onSelect,
@@ -43,8 +44,6 @@
 		onSelect(gif.originalUrl);
 		onClose();
 	}
-
-	const isTouchDevice = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
 
 	onMount(() => {
 		loadTrending();

--- a/apps/web/src/lib/components/dm/DmChatArea.svelte
+++ b/apps/web/src/lib/components/dm/DmChatArea.svelte
@@ -17,9 +17,13 @@
 	import MessageActionBar from '$lib/components/chat/MessageActionBar.svelte';
 	import ReactionBar from '$lib/components/chat/ReactionBar.svelte';
 	import { extractYouTubeUrls } from '$lib/utils/youtube.js';
+	import EmojiPicker from '$lib/components/chat/EmojiPicker.svelte';
+	import GifPicker from '$lib/components/chat/GifPicker.svelte';
 	import DmCallHeader from '$lib/components/voice/DmCallHeader.svelte';
 	import VideoGrid from '$lib/components/voice/VideoGrid.svelte';
 	import SearchPanel from '$lib/components/search/SearchPanel.svelte';
+	import { recordEmojiUse, getFrequentEmojis } from '$lib/utils/emoji-frequency.js';
+	import { isTouchDevice } from '$lib/utils/dom.js';
 
 	const auth = getAuthStore();
 	const ui = getUIStore();
@@ -263,6 +267,33 @@
 		if (dmOverlayEl && dmInputEl) {
 			dmOverlayEl.scrollLeft = dmInputEl.scrollLeft;
 		}
+	}
+
+	/* ───── Emoji / GIF picker ───── */
+	let showDmPicker = $state(false);
+	let dmPickerTab = $state<'emoji' | 'gif'>('emoji');
+	let dmQuickEmojis = $state(getFrequentEmojis(8));
+
+	function handleDmEmojiInsert(emoji: string) {
+		recordEmojiUse(emoji);
+		dmQuickEmojis = getFrequentEmojis(8);
+		if (!dmInputEl) return;
+		const start = dmInputEl.selectionStart ?? dms.dmMessageBody.length;
+		const end = dmInputEl.selectionEnd ?? start;
+		const before = dms.dmMessageBody.slice(0, start);
+		const after = dms.dmMessageBody.slice(end);
+		dms.dmMessageBody = before + emoji + after;
+		const newPos = start + emoji.length;
+		requestAnimationFrame(() => {
+			dmInputEl.focus();
+			dmInputEl.setSelectionRange(newPos, newPos);
+		});
+	}
+
+	function handleDmGifSelect(gifUrl: string) {
+		showDmPicker = false;
+		dmPickerTab = 'emoji';
+		dms.sendDmGifMessage(gifUrl);
 	}
 
 	/* ───── Drag-and-drop image ───── */
@@ -625,6 +656,32 @@
 				</button>
 			</div>
 		{/if}
+		{#if isTouchDevice && ui.isHubConnected && !showDmPicker && !dms.replyingTo && dms.activeDmChannelId}
+			<div class="quick-emoji-bar" role="toolbar" aria-label="Quick emoji">
+				{#each dmQuickEmojis as emoji (emoji)}
+					{@const customMatch = emoji.startsWith(':') && emoji.endsWith(':')
+						? servers.customEmojis.find((c) => `:${c.name}:` === emoji)
+						: undefined}
+					<button
+						type="button"
+						class="quick-emoji-btn"
+						onclick={() => handleDmEmojiInsert(emoji)}
+					>{#if customMatch}<img src={customMatch.imageUrl} alt={customMatch.name} width="22" height="22" class="quick-emoji-img" />{:else}{emoji}{/if}</button>
+				{/each}
+				<button
+					type="button"
+					class="quick-emoji-btn quick-emoji-more"
+					onclick={() => { showDmPicker = true; dmPickerTab = 'emoji'; }}
+					aria-label="Open emoji picker"
+					title="More emojis"
+				>
+					<svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+						<path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm0 1a6 6 0 1 1 0 12A6 6 0 0 1 8 2Zm-2.5 4a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5Zm5 0a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5ZM4.5 9.5a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 .383.82A3.98 3.98 0 0 1 8 11.5a3.98 3.98 0 0 1-2.883-1.68A.5.5 0 0 1 5 9.5h-1Z"/>
+					</svg>
+				</button>
+			</div>
+		{/if}
+
 		{#if !ui.isHubConnected}
 			<div class="composer-row">
 				<div class="composer-input-wrapper composer-disconnected">
@@ -662,6 +719,18 @@
 				/>
 			</div>
 			<button
+				class="composer-emoji"
+				type="button"
+				onclick={() => { showDmPicker = !showDmPicker; if (showDmPicker) dmPickerTab = 'emoji'; }}
+				disabled={!dms.activeDmChannelId || dms.isSendingDm}
+				aria-label="Add emoji or GIF"
+				title="Add emoji or GIF"
+			>
+				<svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+					<path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm0 1a6 6 0 1 1 0 12A6 6 0 0 1 8 2Zm-2.5 4a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5Zm5 0a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5ZM4.5 9.5a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 .383.82A3.98 3.98 0 0 1 8 11.5a3.98 3.98 0 0 1-2.883-1.68A.5.5 0 0 1 5 9.5h-1Z"/>
+				</svg>
+			</button>
+			<button
 				class="composer-send"
 				type="submit"
 				disabled={!dms.activeDmChannelId || (!dms.dmMessageBody.trim() && !dms.pendingDmImage && !dms.pendingDmFile) || dms.isSendingDm}
@@ -672,6 +741,44 @@
 				</svg>
 			</button>
 			</div>
+			{#if showDmPicker}
+				<div class="composer-picker-wrapper">
+					<!-- svelte-ignore a11y_no_static_element_interactions -->
+					<div class="picker-backdrop" onclick={() => { showDmPicker = false; }}></div>
+					<div class="picker-container" role="dialog" aria-label="Emoji and GIF picker">
+						<div class="picker-tab-bar">
+							<button
+								class="picker-tab"
+								class:active={dmPickerTab === 'emoji'}
+								type="button"
+								onclick={() => (dmPickerTab = 'emoji')}
+							>Emoji</button>
+							<button
+								class="picker-tab"
+								class:active={dmPickerTab === 'gif'}
+								type="button"
+								onclick={() => (dmPickerTab = 'gif')}
+							>GIFs</button>
+						</div>
+						<div class="picker-body">
+							{#if dmPickerTab === 'emoji'}
+								<EmojiPicker
+									mode="insert"
+									embedded={true}
+									onSelect={handleDmEmojiInsert}
+									onClose={() => { showDmPicker = false; }}
+									customEmojis={servers.customEmojis}
+								/>
+							{:else}
+								<GifPicker
+									onSelect={handleDmGifSelect}
+									onClose={() => { showDmPicker = false; }}
+								/>
+							{/if}
+						</div>
+					</div>
+				</div>
+			{/if}
 		{/if}
 		</form>
 	</div>
@@ -1131,6 +1238,86 @@
 		cursor: not-allowed;
 	}
 
+	.composer-emoji {
+		background: var(--input-bg);
+		border: none;
+		box-sizing: border-box;
+		padding: 9px 6px;
+		color: var(--text-muted);
+		cursor: pointer;
+		display: grid;
+		place-items: center;
+		flex-shrink: 0;
+		transition: color 150ms ease;
+	}
+
+	.composer-emoji:hover:not(:disabled) { color: var(--accent); }
+
+	.composer-emoji:disabled {
+		opacity: 0.3;
+		cursor: not-allowed;
+	}
+
+	.composer-picker-wrapper {
+		position: relative;
+	}
+
+	.picker-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 99;
+	}
+
+	.picker-container {
+		position: absolute;
+		z-index: 100;
+		bottom: calc(100% + 4px);
+		right: 0;
+		width: 352px;
+		max-height: 420px;
+		display: flex;
+		flex-direction: column;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: 8px;
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+		overflow: hidden;
+	}
+
+	.picker-tab-bar {
+		display: flex;
+		border-bottom: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+
+	.picker-tab {
+		flex: 1;
+		padding: 8px 12px;
+		background: none;
+		border: none;
+		border-bottom: 2px solid transparent;
+		color: var(--text-muted);
+		font-size: 0.85rem;
+		font-weight: 600;
+		cursor: pointer;
+		transition: color 0.15s, border-color 0.15s;
+	}
+
+	.picker-tab:hover { color: var(--text-primary); }
+
+	.picker-tab.active {
+		color: var(--accent);
+		border-bottom-color: var(--accent);
+	}
+
+	.picker-body {
+		flex: 1;
+		min-height: 0;
+		overflow: hidden;
+		display: flex;
+		flex-direction: column;
+	}
+
 	/* ───── Disconnected state ───── */
 
 	.composer-disconnected {
@@ -1436,6 +1623,10 @@
 
 	/* ───── Mobile adjustments ───── */
 
+	.quick-emoji-bar {
+		display: none;
+	}
+
 	@media (max-width: 768px) {
 		.system-message.voice-call-event {
 			background: var(--bg-secondary);
@@ -1456,8 +1647,87 @@
 			min-height: 44px;
 		}
 
+		.composer-emoji {
+			min-width: 44px;
+			min-height: 44px;
+		}
+
 		.dm-chat .composer {
 			padding: 0 16px calc(16px + env(safe-area-inset-bottom, 0));
 		}
+
+		/* Quick emoji bar */
+		.quick-emoji-bar {
+			display: flex;
+			align-items: center;
+			gap: 2px;
+			padding: 6px 8px;
+			overflow-x: auto;
+			-webkit-overflow-scrolling: touch;
+			scrollbar-width: none;
+		}
+
+		.quick-emoji-bar::-webkit-scrollbar {
+			display: none;
+		}
+
+		.quick-emoji-btn {
+			flex-shrink: 0;
+			display: grid;
+			place-items: center;
+			width: 40px;
+			height: 36px;
+			background: var(--bg-tertiary);
+			border: 1px solid var(--border);
+			border-radius: 8px;
+			cursor: pointer;
+			font-size: 20px;
+			line-height: 1;
+			padding: 0;
+			transition: background 0.12s, transform 0.1s;
+		}
+
+		.quick-emoji-btn:active {
+			transform: scale(0.92);
+			background: var(--bg-message-hover);
+		}
+
+		.quick-emoji-more {
+			color: var(--text-muted);
+			font-size: 16px;
+		}
+
+		.quick-emoji-img {
+			object-fit: contain;
+		}
+
+		/* Bottom sheet picker */
+		.picker-container {
+			position: fixed;
+			bottom: 0;
+			left: 0;
+			right: 0;
+			top: unset;
+			width: 100%;
+			max-height: 60vh;
+			border-radius: 12px 12px 0 0;
+			padding-bottom: env(safe-area-inset-bottom);
+			animation: slide-up 200ms ease;
+		}
+
+		.picker-backdrop {
+			background: rgba(0, 0, 0, 0.5);
+		}
+
+		.picker-tab {
+			padding: 12px 16px;
+			font-size: 0.95rem;
+			min-height: 44px;
+		}
+	}
+
+	@keyframes slide-up {
+		from { transform: translateY(100%); }
+		to { transform: translateY(0); }
 	}
 </style>

--- a/apps/web/src/lib/state/dm-store.svelte.ts
+++ b/apps/web/src/lib/state/dm-store.svelte.ts
@@ -209,6 +209,39 @@ export class DmStore {
 		}
 	}
 
+	/** Send a GIF as a DM using the GIPHY URL as the image attachment. */
+	async sendDmGifMessage(gifUrl: string): Promise<void> {
+		if (!this.auth.idToken || !this.activeDmChannelId) return;
+
+		const replyToDirectMessageId =
+			this.replyingTo?.context === 'dm' ? this.replyingTo.messageId : null;
+
+		this.isSendingDm = true;
+		try {
+			await this.api.sendDm(
+				this.auth.idToken,
+				this.activeDmChannelId,
+				'',
+				gifUrl,
+				replyToDirectMessageId,
+				null
+			);
+			this.replyingTo = null;
+
+			if (this.auth.me) {
+				this.hub.clearDmTyping(this.activeDmChannelId, this.auth.effectiveDisplayName);
+			}
+
+			if (!this.hub.isConnected) {
+				await this.loadDmMessages(this.activeDmChannelId);
+			}
+		} catch (e) {
+			this.ui.setError(e);
+		} finally {
+			this.isSendingDm = false;
+		}
+	}
+
 	/** Open or create a DM conversation with a friend. */
 	async openDmWithUser(userId: string): Promise<void> {
 		if (!this.auth.idToken) return;

--- a/apps/web/src/lib/utils/dom.ts
+++ b/apps/web/src/lib/utils/dom.ts
@@ -1,3 +1,7 @@
+/** Whether the primary pointer is coarse (touch device). Evaluated once at module load. */
+export const isTouchDevice =
+	typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
+
 /** Find the nearest ancestor with overflow-y: auto or scroll (the clipping boundary). */
 export function findScrollParent(el: HTMLElement): HTMLElement | null {
 	let parent = el.parentElement;


### PR DESCRIPTION
- Convert emoji/GIF picker to a bottom sheet on mobile (fixed position,
  slide-up animation, full width, 55vh max height)
- Skip auto-focusing search inputs on touch devices to avoid summoning
  the virtual keyboard when browsing emojis/GIFs
- Add quick-access emoji bar above composer on mobile that shows 8
  frequently-used emojis for one-tap insertion without opening the picker
- Add mobile-specific styles to GIF picker (16px font to prevent iOS
  zoom, 44px touch targets)
- Enlarge emoji category tabs and search inputs on mobile for better
  touch targets

https://claude.ai/code/session_015LV56xmv8rTTT5bRsFCJnW