### PR TITLE
fix(web): make message emoji picker accessible on mobile

### DIFF
--- a/apps/web/src/lib/components/chat/MessageItem.svelte
+++ b/apps/web/src/lib/components/chat/MessageItem.svelte
@@ -127,10 +127,12 @@ import { ReportType } from '$lib/types/index.js';
 	<span class="system-message-text">{message.body}</span>
 </div>
 {:else}
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <article
 	class="message"
 	class:grouped
 	class:mentioned={isMentioned}
+	tabindex="0"
 >
 	<!-- Floating action bar — appears on hover at top-right of message -->
 	<MessageActionBar
@@ -506,6 +508,15 @@ import { ReportType } from '$lib/types/index.js';
 		.message .message-time-inline {
 			color: var(--text-muted);
 			opacity: 0.5;
+		}
+
+		/* Highlight tapped message on mobile (no hover available) */
+		.message:focus-within {
+			background: var(--bg-message-hover);
+		}
+
+		.message:focus {
+			outline: none;
 		}
 	}
 	.pin-indicator {


### PR DESCRIPTION
## Summary
- Fixes #161 — emoji picker not showing on mobile
- The message action bar relied on CSS `:hover` to become visible, which doesn't work on touch devices
- Added `tabindex="0"` to message `<article>` elements so tapping a message triggers the existing `:focus-within` CSS rule, making the action bar (and its emoji button) accessible
- Added mobile-only focus background highlight for visual feedback

## Test plan
- [ ] On a mobile device (or Chrome DevTools mobile emulator), open a text channel
- [ ] Tap on a message — the action bar should appear at the top-right
- [ ] Tap the emoji (smiley face) button — the quick emoji picker should open
- [ ] Tap "More emojis" — the full emoji picker should open
- [ ] Tap outside the message — the action bar should dismiss
- [ ] Verify desktop hover behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)