### PR TITLE
fix(infra): keep transitional secrets for old Container App revision

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -394,7 +394,7 @@ module apiApp 'modules/container-app-api.bicep' = {
     livekitApiSecretKvUrl: voiceVmEnabled ? '${keyVault.outputs.uri}secrets/LiveKit--ApiSecret' : ''
     jwtSecretKvUrl: '${keyVault.outputs.uri}secrets/Jwt--Secret'
     gitHubTokenKvUrl: gitHubToken != '' ? '${keyVault.outputs.uri}secrets/GitHub--Token' : ''
-    redisConnectionStringKvUrl: redisEnabled ? redisCache.outputs.connectionStringSecretUri : ''
+    redisConnectionStringKvUrl: redisCache.?outputs.connectionStringSecretUri ?? ''
     appInsightsConnectionString: appInsights.outputs.connectionString
     emailConnectionStringKvUrl: emailEnabled ? communicationServices.?outputs.connectionStringSecretUri ?? '' : ''
     emailSenderAddress: emailEnabled ? communicationServices.?outputs.senderAddress ?? emailSenderAddress : emailSenderAddress
@@ -419,7 +419,7 @@ module webApp 'modules/container-app-web.bicep' = {
     publicGoogleClientId: googleClientId
     publicRecaptchaSiteKey: recaptchaSiteKey
     publicGiphyApiKey: giphyApiKey
-    publicLivekitUrl: voiceVmEnabled ? voiceVm.outputs.livekitUrl : ''
+    publicLivekitUrl: voiceVm.?outputs.livekitUrl ?? ''
     customDomainName: webCustomDomain
     managedCertificateId: webCertId
   }

--- a/infra/modules/container-app-api.bicep
+++ b/infra/modules/container-app-api.bicep
@@ -22,6 +22,7 @@ param livekitServerUrl string = ''
 param livekitApiKeyKvUrl string = ''
 
 @description('Key Vault secret URL for the LiveKit API secret. Leave empty if voice is not enabled.')
+@secure()
 param livekitApiSecretKvUrl string = ''
 
 @description('Key Vault secret URL for the JWT signing secret (email/password auth).')
@@ -135,6 +136,16 @@ resource apiApp 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'jwt-secret'
           keyVaultUrl: jwtSecretKvUrl
           identity: 'system'
+        }
+        // Transitional: old revisions still reference these deleted mediasoup secrets.
+        // Keep them with dummy values until all old revisions are deactivated, then remove.
+        {
+          name: 'voice-turn-secret'
+          value: 'deprecated'
+        }
+        {
+          name: 'voice-sfu-internal-key'
+          value: 'deprecated'
         }
       ], livekitApiKeyKvUrl != '' ? [
         {

--- a/infra/modules/voice-vm.bicep
+++ b/infra/modules/voice-vm.bicep
@@ -36,7 +36,6 @@ param vmSize string = 'Standard_D2als_v7'
 
 // ── Port constants ──────────────────────────────────────────────────────────────
 var turnPort        = 3478
-var signalPort      = 7880
 var rtcTcpPort      = 7881
 var rtcMinPort      = 50000
 var rtcMaxPort      = 60000


### PR DESCRIPTION
## Summary

- Fixes the infra pipeline failure caused by removing `voice-turn-secret` and `voice-sfu-internal-key` secrets that the active API revision still references. Adds them back as dummy `deprecated` values.
- Fixes Bicep linter warnings: adds `@secure()` to `livekitApiSecretKvUrl`, uses safe-access `?.` for conditional module outputs, removes unused `signalPort` variable.

## Type of Change

- [x] Bug fix

## Testing

- [x] API builds (`dotnet build`)

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] The transitional secrets contain only the literal string `deprecated`, not real credentials
- [x] Added `@secure()` to `livekitApiSecretKvUrl` parameter per Bicep linter recommendation