### PR TITLE
fix(infra): skip LiveKit KV secrets when credentials are empty

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -394,7 +394,7 @@ module apiApp 'modules/container-app-api.bicep' = {
     livekitApiSecretKvUrl: voiceVmEnabled ? '${keyVault.outputs.uri}secrets/LiveKit--ApiSecret' : ''
     jwtSecretKvUrl: '${keyVault.outputs.uri}secrets/Jwt--Secret'
     gitHubTokenKvUrl: gitHubToken != '' ? '${keyVault.outputs.uri}secrets/GitHub--Token' : ''
-    redisConnectionStringKvUrl: redisEnabled ? redisCache.outputs.connectionStringSecretUri : ''
+    redisConnectionStringKvUrl: redisCache.?outputs.connectionStringSecretUri ?? ''
     appInsightsConnectionString: appInsights.outputs.connectionString
     emailConnectionStringKvUrl: emailEnabled ? communicationServices.?outputs.connectionStringSecretUri ?? '' : ''
     emailSenderAddress: emailEnabled ? communicationServices.?outputs.senderAddress ?? emailSenderAddress : emailSenderAddress
@@ -419,7 +419,7 @@ module webApp 'modules/container-app-web.bicep' = {
     publicGoogleClientId: googleClientId
     publicRecaptchaSiteKey: recaptchaSiteKey
     publicGiphyApiKey: giphyApiKey
-    publicLivekitUrl: voiceVmEnabled ? voiceVm.outputs.livekitUrl : ''
+    publicLivekitUrl: voiceVm.?outputs.livekitUrl ?? ''
     customDomainName: webCustomDomain
     managedCertificateId: webCertId
   }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -311,7 +311,8 @@ module voiceVm 'modules/voice-vm.bicep' = if (voiceVmEnabled) {
 }
 
 // Store the LiveKit API key in Key Vault so the API Container App can reference it securely.
-module livekitApiKeyKv 'modules/key-vault-secret.bicep' = if (voiceVmEnabled) {
+// Only create when the value is provided — empty secrets cause Container App provisioning failures.
+module livekitApiKeyKv 'modules/key-vault-secret.bicep' = if (voiceVmEnabled && livekitApiKey != '') {
   name: 'livekit-api-key'
   params: {
     keyVaultName: keyVault.outputs.name
@@ -321,7 +322,7 @@ module livekitApiKeyKv 'modules/key-vault-secret.bicep' = if (voiceVmEnabled) {
 }
 
 // Store the LiveKit API secret in Key Vault.
-module livekitApiSecretKv 'modules/key-vault-secret.bicep' = if (voiceVmEnabled) {
+module livekitApiSecretKv 'modules/key-vault-secret.bicep' = if (voiceVmEnabled && livekitApiSecret != '') {
   name: 'livekit-api-secret'
   params: {
     keyVaultName: keyVault.outputs.name
@@ -390,8 +391,8 @@ module apiApp 'modules/container-app-api.bicep' = {
     customDomainName: apiCustomDomain
     managedCertificateId: apiCertId
     livekitServerUrl: voiceVm.?outputs.livekitUrl ?? ''
-    livekitApiKeyKvUrl: voiceVmEnabled ? '${keyVault.outputs.uri}secrets/LiveKit--ApiKey' : ''
-    livekitApiSecretKvUrl: voiceVmEnabled ? '${keyVault.outputs.uri}secrets/LiveKit--ApiSecret' : ''
+    livekitApiKeyKvUrl: voiceVmEnabled && livekitApiKey != '' ? '${keyVault.outputs.uri}secrets/LiveKit--ApiKey' : ''
+    livekitApiSecretKvUrl: voiceVmEnabled && livekitApiSecret != '' ? '${keyVault.outputs.uri}secrets/LiveKit--ApiSecret' : ''
     jwtSecretKvUrl: '${keyVault.outputs.uri}secrets/Jwt--Secret'
     gitHubTokenKvUrl: gitHubToken != '' ? '${keyVault.outputs.uri}secrets/GitHub--Token' : ''
     redisConnectionStringKvUrl: redisCache.?outputs.connectionStringSecretUri ?? ''

--- a/infra/modules/container-app-api.bicep
+++ b/infra/modules/container-app-api.bicep
@@ -22,6 +22,7 @@ param livekitServerUrl string = ''
 param livekitApiKeyKvUrl string = ''
 
 @description('Key Vault secret URL for the LiveKit API secret. Leave empty if voice is not enabled.')
+@secure()
 param livekitApiSecretKvUrl string = ''
 
 @description('Key Vault secret URL for the JWT signing secret (email/password auth).')
@@ -135,6 +136,16 @@ resource apiApp 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'jwt-secret'
           keyVaultUrl: jwtSecretKvUrl
           identity: 'system'
+        }
+        // Transitional: old revisions still reference these deleted mediasoup secrets.
+        // Keep them with dummy values until all old revisions are deactivated, then remove.
+        {
+          name: 'voice-turn-secret'
+          value: 'deprecated'
+        }
+        {
+          name: 'voice-sfu-internal-key'
+          value: 'deprecated'
         }
       ], livekitApiKeyKvUrl != '' ? [
         {

--- a/infra/modules/voice-vm.bicep
+++ b/infra/modules/voice-vm.bicep
@@ -36,7 +36,6 @@ param vmSize string = 'Standard_D2als_v7'
 
 // ── Port constants ──────────────────────────────────────────────────────────────
 var turnPort        = 3478
-var signalPort      = 7880
 var rtcTcpPort      = 7881
 var rtcMinPort      = 50000
 var rtcMaxPort      = 60000


### PR DESCRIPTION
## Summary

- Only create LiveKit Key Vault secrets and reference them from the Container App when the actual credential values are provided (non-empty).
- Fixes: `Unable to get value using Managed identity system for secret livekit-api-key` — the KV secrets were being created with empty values when `LIVEKIT_API_KEY`/`LIVEKIT_API_SECRET` GitHub secrets aren't set.

## Type of Change

- [x] Bug fix

## Security Checklist

- [x] No secrets or credentials added to source control