### PR TITLE
fix(web): pass LiveKit URL via store factory parameter

### DIFF
--- a/apps/web/src/lib/state/voice-store.svelte.ts
+++ b/apps/web/src/lib/state/voice-store.svelte.ts
@@ -1,6 +1,5 @@
 // apps/web/src/lib/state/voice-store.svelte.ts
 import { getContext, setContext } from 'svelte';
-import { env } from '$env/dynamic/public';
 import type { VoiceChannelMember, Channel } from '$lib/types/index.js';
 import type { ApiClient } from '$lib/api/client.js';
 import type { ChatHubService } from '$lib/services/chat-hub.js';
@@ -25,9 +24,10 @@ export function createVoiceStore(
 	api: ApiClient,
 	ui: UIStore,
 	hub: ChatHubService,
-	voice: VoiceService
+	voice: VoiceService,
+	liveKitUrl: string
 ): VoiceStore {
-	const store = new VoiceStore(auth, api, ui, hub, voice);
+	const store = new VoiceStore(auth, api, ui, hub, voice, liveKitUrl);
 	setContext(VOICE_KEY, store);
 	return store;
 }
@@ -101,11 +101,12 @@ export class VoiceStore {
 		private readonly api: ApiClient,
 		private readonly ui: UIStore,
 		private readonly hub: ChatHubService,
-		private readonly voice: VoiceService
+		private readonly voice: VoiceService,
+		liveKitUrl: string
 	) {
 		this._loadUserVolumes();
 		this._loadVoicePreferences();
-		this.liveKitUrl = env.PUBLIC_LIVEKIT_URL || 'ws://localhost:7880';
+		this.liveKitUrl = liveKitUrl || 'ws://localhost:7880';
 	}
 
 	/* ��══════════════════ Core Voice ═══════════════════ */

--- a/apps/web/src/lib/state/voice-store.svelte.ts
+++ b/apps/web/src/lib/state/voice-store.svelte.ts
@@ -1,5 +1,6 @@
 // apps/web/src/lib/state/voice-store.svelte.ts
 import { getContext, setContext } from 'svelte';
+import { env } from '$env/dynamic/public';
 import type { VoiceChannelMember, Channel } from '$lib/types/index.js';
 import type { ApiClient } from '$lib/api/client.js';
 import type { ChatHubService } from '$lib/services/chat-hub.js';
@@ -104,7 +105,7 @@ export class VoiceStore {
 	) {
 		this._loadUserVolumes();
 		this._loadVoicePreferences();
-		this.liveKitUrl = import.meta.env.PUBLIC_LIVEKIT_URL || 'ws://localhost:7880';
+		this.liveKitUrl = env.PUBLIC_LIVEKIT_URL || 'ws://localhost:7880';
 	}
 
 	/* ��══════════════════ Core Voice ═══════════════════ */

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -56,7 +56,7 @@
 	const messages = createMessageStore(auth, channels, api, ui, hub);
 	const dms = createDmStore(auth, api, ui, hub);
 	const friends = createFriendStore(auth, api, ui);
-	const voice = createVoiceStore(auth, api, ui, hub, new VoiceService());
+	const voice = createVoiceStore(auth, api, ui, hub, new VoiceService(), env.PUBLIC_LIVEKIT_URL ?? '');
 	const announcementStore = createAnnouncementStore();
 
 	/* ───── Wire cross-store callbacks ───── */

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -310,24 +310,28 @@ module voiceVm 'modules/voice-vm.bicep' = if (voiceVmEnabled) {
   }
 }
 
+// Effective LiveKit credentials: use provided values or fallback dev keys when voice is enabled.
+// Both the voice VM (via CD pipeline) and the API container must use matching credentials.
+var effectiveLivekitApiKey = livekitApiKey != '' ? livekitApiKey : 'devkey'
+var effectiveLivekitApiSecret = livekitApiSecret != '' ? livekitApiSecret : 'secret-must-be-at-least-32-chars'
+
 // Store the LiveKit API key in Key Vault so the API Container App can reference it securely.
-// Only create when the value is provided — empty secrets cause Container App provisioning failures.
-module livekitApiKeyKv 'modules/key-vault-secret.bicep' = if (voiceVmEnabled && livekitApiKey != '') {
+module livekitApiKeyKv 'modules/key-vault-secret.bicep' = if (voiceVmEnabled) {
   name: 'livekit-api-key'
   params: {
     keyVaultName: keyVault.outputs.name
     secretName: 'LiveKit--ApiKey'
-    secretValue: livekitApiKey
+    secretValue: effectiveLivekitApiKey
   }
 }
 
 // Store the LiveKit API secret in Key Vault.
-module livekitApiSecretKv 'modules/key-vault-secret.bicep' = if (voiceVmEnabled && livekitApiSecret != '') {
+module livekitApiSecretKv 'modules/key-vault-secret.bicep' = if (voiceVmEnabled) {
   name: 'livekit-api-secret'
   params: {
     keyVaultName: keyVault.outputs.name
     secretName: 'LiveKit--ApiSecret'
-    secretValue: livekitApiSecret
+    secretValue: effectiveLivekitApiSecret
   }
 }
 
@@ -391,8 +395,8 @@ module apiApp 'modules/container-app-api.bicep' = {
     customDomainName: apiCustomDomain
     managedCertificateId: apiCertId
     livekitServerUrl: voiceVm.?outputs.livekitUrl ?? ''
-    livekitApiKeyKvUrl: voiceVmEnabled && livekitApiKey != '' ? '${keyVault.outputs.uri}secrets/LiveKit--ApiKey' : ''
-    livekitApiSecretKvUrl: voiceVmEnabled && livekitApiSecret != '' ? '${keyVault.outputs.uri}secrets/LiveKit--ApiSecret' : ''
+    livekitApiKeyKvUrl: voiceVmEnabled ? '${keyVault.outputs.uri}secrets/LiveKit--ApiKey' : ''
+    livekitApiSecretKvUrl: voiceVmEnabled ? '${keyVault.outputs.uri}secrets/LiveKit--ApiSecret' : ''
     jwtSecretKvUrl: '${keyVault.outputs.uri}secrets/Jwt--Secret'
     gitHubTokenKvUrl: gitHubToken != '' ? '${keyVault.outputs.uri}secrets/GitHub--Token' : ''
     redisConnectionStringKvUrl: redisCache.?outputs.connectionStringSecretUri ?? ''


### PR DESCRIPTION
Fixes voice connecting to ws://localhost:7880 in production. Passes PUBLIC_LIVEKIT_URL from +page.svelte (where $env/dynamic/public works) through createVoiceStore instead of importing it inside the .svelte.ts module.