### PR TITLE
fix: use toSorted() to prevent channel sidebar freeze after Discord import

### DIFF
--- a/apps/web/src/lib/components/channel-sidebar/ChannelSidebar.svelte
+++ b/apps/web/src/lib/components/channel-sidebar/ChannelSidebar.svelte
@@ -33,7 +33,7 @@
 
 	const categorizedGroups = $derived(
 		servers.categories
-			.sort((a, b) => a.position - b.position)
+			.toSorted((a, b) => a.position - b.position)
 			.map((cat) => ({
 				...cat,
 				channels: channelStore.channels


### PR DESCRIPTION
## Summary

- Changes `.sort()` to `.toSorted()` on `servers.categories` in `ChannelSidebar.svelte` to avoid mutating a `$state` array inside a `$derived` block.
- `.sort()` mutates in-place, which triggers Svelte 5's `state_unsafe_mutation` error and freezes the channel sidebar — making text channels unselectable after a Discord import creates categories.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore

## Testing

- [ ] API builds (`dotnet build`)
- [x] Web builds (`npm run build`)
- [x] Svelte checks (`npx svelte-check`)
- [ ] Manual end-to-end check performed

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
- [x] Authz/authn impacts reviewed (if applicable)

## Notes for Reviewers

One-line fix. The bug only manifested after Discord import because that's when `servers.categories` first gets populated with 2+ items, causing `.sort()` to actually write to the reactive proxy and trigger the error.