### PR TITLE
fix: resolve Discord import rendering bugs (CSP, dupes, authors, categories)

### DIFF
--- a/apps/api/Codec.Api/Controllers/ChannelsController.cs
+++ b/apps/api/Codec.Api/Controllers/ChannelsController.cs
@@ -96,7 +96,9 @@ public partial class ChannelsController(CodecDbContext db, IUserService userServ
                     m.ReplyToMessageId,
                     AuthorCustomAvatarPath = m.AuthorUser != null ? m.AuthorUser.CustomAvatarPath : null,
                     AuthorGoogleAvatarUrl = m.AuthorUser != null ? m.AuthorUser.AvatarUrl : null,
-                    m.MessageType
+                    m.MessageType,
+                    m.ImportedAuthorName,
+                    m.ImportedAuthorAvatarUrl
                 })
                 .FirstOrDefaultAsync();
 
@@ -129,7 +131,9 @@ public partial class ChannelsController(CodecDbContext db, IUserService userServ
                     m.ReplyToMessageId,
                     AuthorCustomAvatarPath = m.AuthorUser != null ? m.AuthorUser.CustomAvatarPath : null,
                     AuthorGoogleAvatarUrl = m.AuthorUser != null ? m.AuthorUser.AvatarUrl : null,
-                    m.MessageType
+                    m.MessageType,
+                    m.ImportedAuthorName,
+                    m.ImportedAuthorAvatarUrl
                 })
                 .ToListAsync();
 
@@ -157,7 +161,9 @@ public partial class ChannelsController(CodecDbContext db, IUserService userServ
                     m.ReplyToMessageId,
                     AuthorCustomAvatarPath = m.AuthorUser != null ? m.AuthorUser.CustomAvatarPath : null,
                     AuthorGoogleAvatarUrl = m.AuthorUser != null ? m.AuthorUser.AvatarUrl : null,
-                    m.MessageType
+                    m.MessageType,
+                    m.ImportedAuthorName,
+                    m.ImportedAuthorAvatarUrl
                 })
                 .ToListAsync();
 
@@ -288,6 +294,8 @@ public partial class ChannelsController(CodecDbContext db, IUserService userServ
                     message.EditedAt,
                     message.ChannelId,
                     AuthorAvatarUrl = avatarService.ResolveUrl(message.AuthorCustomAvatarPath) ?? message.AuthorGoogleAvatarUrl,
+                    message.ImportedAuthorName,
+                    message.ImportedAuthorAvatarUrl,
                     Reactions = aroundReactionLookup.TryGetValue(message.Id, out var reactions)
                         ? reactions
                         : Array.Empty<ReactionSummary>(),
@@ -337,7 +345,9 @@ public partial class ChannelsController(CodecDbContext db, IUserService userServ
                 message.ReplyToMessageId,
                 AuthorCustomAvatarPath = message.AuthorUser != null ? message.AuthorUser.CustomAvatarPath : null,
                 AuthorGoogleAvatarUrl = message.AuthorUser != null ? message.AuthorUser.AvatarUrl : null,
-                message.MessageType
+                message.MessageType,
+                message.ImportedAuthorName,
+                message.ImportedAuthorAvatarUrl
             })
             .ToListAsync();
 
@@ -469,6 +479,8 @@ public partial class ChannelsController(CodecDbContext db, IUserService userServ
                 message.EditedAt,
                 message.ChannelId,
                 AuthorAvatarUrl = avatarService.ResolveUrl(message.AuthorCustomAvatarPath) ?? message.AuthorGoogleAvatarUrl,
+                message.ImportedAuthorName,
+                message.ImportedAuthorAvatarUrl,
                 Reactions = reactionLookup.TryGetValue(message.Id, out var reactions)
                     ? reactions
                     : Array.Empty<ReactionSummary>(),
@@ -1082,6 +1094,8 @@ public partial class ChannelsController(CodecDbContext db, IUserService userServ
                     editedAt = msg.EditedAt,
                     channelId = msg.ChannelId,
                     authorAvatarUrl = avatarService.ResolveUrl(msg.AuthorUser?.CustomAvatarPath) ?? msg.AuthorUser?.AvatarUrl,
+                    importedAuthorName = msg.ImportedAuthorName,
+                    importedAuthorAvatarUrl = msg.ImportedAuthorAvatarUrl,
                     reactions = reactionLookup.TryGetValue(msg.Id, out var reactions) ? reactions : Array.Empty<ReactionSummary>(),
                     linkPreviews = linkPreviewLookup.TryGetValue(msg.Id, out var previews) ? previews : Array.Empty<LinkPreviewDto>(),
                     mentions = Array.Empty<object>(),

--- a/apps/api/Codec.Api/Controllers/ServersController.cs
+++ b/apps/api/Codec.Api/Controllers/ServersController.cs
@@ -2203,7 +2203,9 @@ public partial class ServersController(CodecDbContext db, IUserService userServi
                 m.ChannelId,
                 m.ReplyToMessageId,
                 AuthorCustomAvatarPath = m.AuthorUser != null ? m.AuthorUser.CustomAvatarPath : null,
-                AuthorGoogleAvatarUrl = m.AuthorUser != null ? m.AuthorUser.AvatarUrl : null
+                AuthorGoogleAvatarUrl = m.AuthorUser != null ? m.AuthorUser.AvatarUrl : null,
+                m.ImportedAuthorName,
+                m.ImportedAuthorAvatarUrl
             })
             .ToListAsync();
 
@@ -2327,6 +2329,8 @@ public partial class ServersController(CodecDbContext db, IUserService userServi
                 message.AuthorName,
                 message.AuthorUserId,
                 AuthorAvatarUrl = avatarService.ResolveUrl(message.AuthorCustomAvatarPath) ?? message.AuthorGoogleAvatarUrl,
+                message.ImportedAuthorName,
+                message.ImportedAuthorAvatarUrl,
                 message.Body,
                 message.ImageUrl,
                 message.FileUrl,

--- a/apps/api/Codec.Api/Services/DiscordApiClient.cs
+++ b/apps/api/Codec.Api/Services/DiscordApiClient.cs
@@ -11,6 +11,7 @@ public class DiscordApiClient
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
         NumberHandling = JsonNumberHandling.AllowReadingFromString
     };
 

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -30,6 +30,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 			'https://cdn.discordapp.com',
 			'https://avatars.githubusercontent.com',
 			'https://*.giphy.com',
+			'https://*.ytimg.com',
 			apiBase
 		].join(' '),
 		'connect-src': `'self' ${apiBase} ${wsBase} ${livekitUrl ? livekitUrl + ' ' : ''}${livekitHttpUrl ? livekitHttpUrl + ' ' : ''}https://accounts.google.com https://www.google.com https://play.google.com https://www.youtube.com https://fonts.googleapis.com https://fonts.gstatic.com https://github.com https://discord.com https://api.giphy.com`,

--- a/apps/web/src/lib/components/members/MembersSidebar.svelte
+++ b/apps/web/src/lib/components/members/MembersSidebar.svelte
@@ -18,8 +18,8 @@ import { ReportType } from '$lib/types/index.js';
 
 	/** Group members by their highest hoisted role, ordered by role position. */
 	const roleGroups = $derived(() => {
-		const groups: { name: string; color?: string | null; members: Member[] }[] = [];
-		const hoisted = new Map<string, { name: string; color?: string | null; position: number; members: Member[] }>();
+		const groups: { id: string; name: string; color?: string | null; members: Member[] }[] = [];
+		const hoisted = new Map<string, { id: string; name: string; color?: string | null; position: number; members: Member[] }>();
 		const unhoisted: Member[] = [];
 
 		for (const m of servers.members) {
@@ -28,7 +28,7 @@ import { ReportType } from '$lib/types/index.js';
 			if (displayRole) {
 				const key = displayRole.id;
 				if (!hoisted.has(key)) {
-					hoisted.set(key, { name: displayRole.name, color: displayRole.color, position: displayRole.position, members: [] });
+					hoisted.set(key, { id: key, name: displayRole.name, color: displayRole.color, position: displayRole.position, members: [] });
 				}
 				hoisted.get(key)!.members.push(m);
 			} else {
@@ -39,11 +39,11 @@ import { ReportType } from '$lib/types/index.js';
 		// Sort groups by position (lower = higher rank)
 		const sorted = [...hoisted.values()].sort((a, b) => a.position - b.position);
 		for (const g of sorted) {
-			groups.push({ name: g.name, color: g.color, members: g.members.sort(byPresence) });
+			groups.push({ id: g.id, name: g.name, color: g.color, members: g.members.sort(byPresence) });
 		}
 
 		if (unhoisted.length > 0) {
-			groups.push({ name: 'Other', color: null, members: unhoisted.sort(byPresence) });
+			groups.push({ id: '_other', name: 'Other', color: null, members: unhoisted.sort(byPresence) });
 		}
 
 		return groups;
@@ -60,7 +60,7 @@ import { ReportType } from '$lib/types/index.js';
 	{:else if servers.members.length === 0}
 		<p class="muted sidebar-status">No members yet.</p>
 	{:else}
-		{#each roleGroups() as group (group.name)}
+		{#each roleGroups() as group (group.id)}
 			{#if group.members.length > 0}
 				<h3 class="member-group-heading">{group.name} — {group.members.length}</h3>
 				<ul class="member-list" role="list">


### PR DESCRIPTION
## Summary

- Fixes four bugs related to PR #160 (Discord server import):
  1. **CSP violation**: YouTube thumbnail images (`i.ytimg.com`) blocked by missing `img-src` entry
  2. **Duplicate key error**: `MembersSidebar` used `group.name` as `{#each}` key, which collided when imported Discord roles shared names — changed to unique role ID
  3. **"Deleted User" on all imported messages**: API query projections omitted `ImportedAuthorName` and `ImportedAuthorAvatarUrl` fields, so the frontend never received them despite having rendering logic ready
  4. **Channels not placed in category groups**: `DiscordApiClient` JSON deserializer lacked `SnakeCaseLower` naming policy, so Discord's `parent_id` never mapped to the C# `ParentId` property — all multi-word snake_case fields (`permission_overwrites`, `global_name`, `message_reference`, `content_type`, `edited_timestamp`) were silently null

## Related Issue

Closes #160 follow-up bugs

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore

## Testing

- [x] API builds (`dotnet build`)
- [x] Web builds (`npm run build`)
- [x] Svelte checks (`npx svelte-check`)
- [x] API unit tests pass (1385 passed)
- [x] Web tests pass (219 passed)
- [ ] Manual end-to-end check performed

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
- [x] Authz/authn impacts reviewed (if applicable)

## Notes for Reviewers

The snake_case deserializer fix (commit 3) is a one-line change with broad positive impact — existing imports will need a re-sync to pick up corrected category assignments, reply threading, image detection, and display names.