### PR TITLE
fix: use highest-ranked custom role for member sidebar grouping

### DIFF
--- a/apps/api/Codec.Api/Controllers/ServersController.cs
+++ b/apps/api/Codec.Api/Controllers/ServersController.cs
@@ -371,7 +371,7 @@ public partial class ServersController(CodecDbContext db, IUserService userServi
             var permissions = roles.Count > 0
                 ? roles.Aggregate(Permission.None, (acc, role) => acc | role.Permissions)
                 : Permission.None;
-            var displayRole = roles.FirstOrDefault(r2 => r2.Color is not null && r2.Color != "");
+            var displayRole = roles.FirstOrDefault(r2 => !r2.IsSystemRole);
             var highestPosition = roles.Count > 0 ? roles.Min(r2 => r2.Position) : int.MaxValue;
 
             return new


### PR DESCRIPTION
## Summary

- Fixes member sidebar always grouping all users under "Other" regardless of their roles.
- The `displayRole` selection previously required a non-empty color, so roles without colors were ignored. Now it selects the highest-ranked non-system role by position, matching standard Discord behavior.

## Type of Change

- [x] Bug fix

## Testing

- [x] API builds (`dotnet build`)
- [x] API unit tests pass (1385 passed)

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
- [x] Authz/authn impacts reviewed (if applicable)

## Notes for Reviewers

Single-line change in `ServersController.GetMembers`. The `roles` list is already sorted by position (line 365), so `FirstOrDefault(r2 => !r2.IsSystemRole)` picks the highest-ranked custom role. Members with only the `@everyone` system role correctly fall to the "Other" group.