### PR TITLE
fix: show inline preview for Discord-imported image attachments

### DIFF
--- a/apps/api/Codec.Api/Services/DiscordImportService.cs
+++ b/apps/api/Codec.Api/Services/DiscordImportService.cs
@@ -523,7 +523,10 @@ public class DiscordImportService
                 if (dm.Attachments is { Count: > 0 })
                 {
                     var att = dm.Attachments[0];
-                    if (att.ContentType?.StartsWith("image/") == true)
+                    var ext = Path.GetExtension(att.Filename)?.ToLowerInvariant();
+                    var isImage = att.ContentType?.StartsWith("image/", StringComparison.OrdinalIgnoreCase) == true
+                        || ext is ".png" or ".jpg" or ".jpeg" or ".gif" or ".webp" or ".svg" or ".bmp" or ".ico" or ".avif";
+                    if (isImage)
                         imageUrl = att.Url;
                     else
                     {

--- a/apps/web/src/lib/components/chat/MessageItem.svelte
+++ b/apps/web/src/lib/components/chat/MessageItem.svelte
@@ -16,6 +16,15 @@ import { ReportType } from '$lib/types/index.js';
 	import { getMessageStore } from '$lib/state/message-store.svelte.js';
 	import { extractYouTubeUrls } from '$lib/utils/youtube.js';
 
+	const imageExtensions = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico', 'avif']);
+
+	function isImageFile(contentType?: string | null, fileName?: string | null): boolean {
+		if (contentType?.startsWith('image/')) return true;
+		if (!fileName) return false;
+		const ext = fileName.split('.').pop()?.toLowerCase() ?? '';
+		return imageExtensions.has(ext);
+	}
+
 	let {
 		message,
 		grouped = false,
@@ -205,7 +214,11 @@ import { ReportType } from '$lib/types/index.js';
 					<img src={message.imageUrl} alt="Uploaded attachment" class="message-image" loading="lazy" />
 				</button>
 			{/if}
-			{#if message.fileUrl && message.fileName}
+			{#if message.fileUrl && message.fileName && isImageFile(message.fileContentType, message.fileName)}
+				<button type="button" class="message-image-link" onclick={() => ui.openImagePreview(message.fileUrl!)}>
+					<img src={message.fileUrl} alt={message.fileName} class="message-image" loading="lazy" />
+				</button>
+			{:else if message.fileUrl && message.fileName}
 				<FileCard fileUrl={message.fileUrl} fileName={message.fileName} fileSize={message.fileSize} fileContentType={message.fileContentType} />
 			{/if}
 			{#if message.linkPreviews?.length}
@@ -268,7 +281,11 @@ import { ReportType } from '$lib/types/index.js';
 					<img src={message.imageUrl} alt="Uploaded attachment" class="message-image" loading="lazy" />
 				</button>
 			{/if}
-			{#if message.fileUrl && message.fileName}
+			{#if message.fileUrl && message.fileName && isImageFile(message.fileContentType, message.fileName)}
+				<button type="button" class="message-image-link" onclick={() => ui.openImagePreview(message.fileUrl!)}>
+					<img src={message.fileUrl} alt={message.fileName} class="message-image" loading="lazy" />
+				</button>
+			{:else if message.fileUrl && message.fileName}
 				<FileCard fileUrl={message.fileUrl} fileName={message.fileName} fileSize={message.fileSize} fileContentType={message.fileContentType} />
 			{/if}
 			{#if message.linkPreviews?.length}


### PR DESCRIPTION
## Summary

- Discord-imported image attachments with null `ContentType` from the Discord API were being classified as generic file downloads, causing them to render as download cards instead of inline image previews in the channel chat.
- **Frontend fix**: `MessageItem.svelte` now detects image files in `fileUrl` by content type or filename extension and renders them as inline `<img>` previews with lightbox support (both compact and full message layouts).
- **Backend fix**: `DiscordImportService.cs` falls back to filename extension (`.png`, `.jpg`, `.gif`, `.webp`, etc.) when `ContentType` is null, and uses case-insensitive comparison for the content type check, so future imports correctly classify images.

## Related Issue

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore

## Testing

- [x] API builds (`dotnet build`)
- [x] Web builds (`npm run build`)
- [x] Svelte checks (`npx svelte-check`)
- [ ] Manual end-to-end check performed

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
- [x] Authz/authn impacts reviewed (if applicable)

## Screenshots / Recordings (if UI changes)

<!-- Before: image attachments from Discord import show as download cards. After: they render as inline image previews with lightbox click-to-expand. -->

## Notes for Reviewers

The frontend fix handles already-imported data (images stored in `fileUrl`), while the backend fix prevents the issue for future imports. The image extension list matches between frontend and backend.