### PR TITLE
fix: resolve Discord import failure from missing libfontconfig in Docker image

### DIFF
--- a/apps/api/Codec.Api/Controllers/DiscordImportController.cs
+++ b/apps/api/Codec.Api/Controllers/DiscordImportController.cs
@@ -145,7 +145,7 @@ public class DiscordImportController : ControllerBase
             .FirstOrDefaultAsync();
 
         if (lastImport is null)
-            return BadRequest(new { error = "No completed or failed import found to re-sync." });
+            return BadRequest(new { error = "No completed import found to re-sync." });
 
         _discordClient.SetBotToken(request.BotToken);
         try

--- a/apps/api/Codec.Api/Controllers/DiscordImportController.cs
+++ b/apps/api/Codec.Api/Controllers/DiscordImportController.cs
@@ -140,12 +140,12 @@ public class DiscordImportController : ControllerBase
         await _userService.EnsurePermissionAsync(serverId, currentUser.Id, Permission.ManageServer, currentUser.IsGlobalAdmin);
 
         var lastImport = await _db.DiscordImports
-            .Where(d => d.ServerId == serverId && d.Status == DiscordImportStatus.Completed)
-            .OrderByDescending(d => d.CompletedAt)
+            .Where(d => d.ServerId == serverId && (d.Status == DiscordImportStatus.Completed || d.Status == DiscordImportStatus.Failed))
+            .OrderByDescending(d => d.CreatedAt)
             .FirstOrDefaultAsync();
 
         if (lastImport is null)
-            return BadRequest(new { error = "No completed import found to re-sync." });
+            return BadRequest(new { error = "No completed or failed import found to re-sync." });
 
         _discordClient.SetBotToken(request.BotToken);
         try

--- a/apps/api/Codec.Api/Services/DiscordImportService.cs
+++ b/apps/api/Codec.Api/Services/DiscordImportService.cs
@@ -156,23 +156,34 @@ public class DiscordImportService
             import.Status = DiscordImportStatus.RehostingMedia;
             await db.SaveChangesAsync(ct);
 
-            // 10. Re-host emoji images
-            await group.SendAsync("ImportProgress", new { stage = "Re-hosting emojis", completed = 0, total = 0, percentComplete = 96f }, ct);
-            await RehostEmojisAsync(db, serverId, importId, group, ct);
-            await db.SaveChangesAsync(ct);
+            try
+            {
+                // 10. Re-host emoji images
+                await group.SendAsync("ImportProgress", new { stage = "Re-hosting emojis", completed = 0, total = 0, percentComplete = 96f }, ct);
+                await RehostEmojisAsync(db, serverId, importId, group, ct);
+                await db.SaveChangesAsync(ct);
 
-            // 11. Re-host message image attachments (newest first)
-            await group.SendAsync("ImportProgress", new { stage = "Re-hosting images", completed = 0, total = 0, percentComplete = 97f }, ct);
-            await RehostAttachmentsAsync(db, serverId, group, ct);
+                // 11. Re-host message image attachments (newest first)
+                await group.SendAsync("ImportProgress", new { stage = "Re-hosting images", completed = 0, total = 0, percentComplete = 97f }, ct);
+                await RehostAttachmentsAsync(db, serverId, group, ct);
 
-            // 12. Re-host non-image file attachments (newest first)
-            await group.SendAsync("ImportProgress", new { stage = "Re-hosting files", completed = 0, total = 0, percentComplete = 98.5f }, ct);
-            await RehostFileAttachmentsAsync(db, serverId, group, ct);
+                // 12. Re-host non-image file attachments (newest first)
+                await group.SendAsync("ImportProgress", new { stage = "Re-hosting files", completed = 0, total = 0, percentComplete = 98.5f }, ct);
+                await RehostFileAttachmentsAsync(db, serverId, group, ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw; // Let the outer catch handle cancellation
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Media re-hosting failed for import {ImportId}, completing import without full re-hosting", importId);
+            }
 
             // Check for cancellation one final time before committing success
             ct.ThrowIfCancellationRequested();
 
-            // Complete
+            // Complete — the text import succeeded even if re-hosting partially failed
             import.Status = DiscordImportStatus.Completed;
             import.CompletedAt = DateTimeOffset.UtcNow;
             import.LastSyncedAt = DateTimeOffset.UtcNow;

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -13,6 +13,9 @@ EXPOSE 8080
 ENV ASPNETCORE_URLS=http://+:8080
 ENV ASPNETCORE_ENVIRONMENT=Production
 
+# SkiaSharp native library requires libfontconfig
+RUN apt-get update && apt-get install -y --no-install-recommends libfontconfig1 && rm -rf /var/lib/apt/lists/*
+
 RUN useradd --no-create-home --shell /bin/false appuser
 USER appuser
 

--- a/apps/web/src/lib/components/server-settings/ServerDiscordImport.svelte
+++ b/apps/web/src/lib/components/server-settings/ServerDiscordImport.svelte
@@ -112,24 +112,42 @@
 			</p>
 		</div>
 
-		<div class="import-form">
-			<h3>Retry Import</h3>
-			<label class="form-label">
-				Bot Token
-				<input type="password" bind:value={botToken} placeholder="Paste your Discord bot token" class="form-input" />
-			</label>
-			<label class="form-label">
-				Discord Guild ID
-				<input type="text" bind:value={guildId} placeholder="e.g. 123456789012345678" class="form-input" />
-			</label>
-			<button
-				class="start-btn"
-				disabled={servers.isStartingImport || !botToken.trim() || !guildId.trim()}
-				onclick={handleStart}
-			>
-				{servers.isStartingImport ? 'Starting...' : 'Retry Import'}
-			</button>
-		</div>
+		{#if importStatus?.importedMessages}
+			<div class="import-form">
+				<h3>Re-sync</h3>
+				<p class="description">The previous import partially succeeded. Re-sync to retry failed steps and pull in any new messages.</p>
+				<label class="form-label">
+					Bot Token
+					<input type="password" bind:value={botToken} placeholder="Paste your Discord bot token" class="form-input" />
+				</label>
+				<button
+					class="start-btn"
+					disabled={servers.isStartingImport || !botToken.trim()}
+					onclick={handleResync}
+				>
+					{servers.isStartingImport ? 'Starting...' : 'Re-sync'}
+				</button>
+			</div>
+		{:else}
+			<div class="import-form">
+				<h3>Retry Import</h3>
+				<label class="form-label">
+					Bot Token
+					<input type="password" bind:value={botToken} placeholder="Paste your Discord bot token" class="form-input" />
+				</label>
+				<label class="form-label">
+					Discord Guild ID
+					<input type="text" bind:value={guildId} placeholder="e.g. 123456789012345678" class="form-input" />
+				</label>
+				<button
+					class="start-btn"
+					disabled={servers.isStartingImport || !botToken.trim() || !guildId.trim()}
+					onclick={handleStart}
+				>
+					{servers.isStartingImport ? 'Starting...' : 'Retry Import'}
+				</button>
+			</div>
+		{/if}
 	{:else if isCompleted}
 		<div class="status-card completed">
 			<h3>Import Complete</h3>


### PR DESCRIPTION
## Summary

- Fixes a production Discord import failure for server `019d84d1-f387-73b9-ac1a-0934f55dde18` where the emoji re-hosting phase crashed with `DllNotFoundException: Unable to load shared library 'libSkiaSharp'` because `libfontconfig1` was missing from the runtime Docker image.
- Makes the media re-hosting phase non-fatal so that a rehosting failure no longer marks the entire import as `Failed` — the text import (channels, messages, members, roles) is preserved as `Completed`.
- Allows resync from failed imports so users don't have to re-import from scratch, and updates the frontend to show a "Re-sync" option when a failed import has partial data.

## Type of Change

- [x] Bug fix

## Testing

- [x] API builds (`dotnet build`)
- [x] API unit tests pass (1385 passed)
- [x] Web tests pass (219 passed)

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
- [x] Authz/authn impacts reviewed (if applicable)

## Notes for Reviewers

Root cause was found by querying Azure Monitor logs (`ContainerAppConsoleLogs_CL`) — the Discord CDN downloads all succeeded (HTTP 200) but `SKBitmap.Decode()` failed because the `mcr.microsoft.com/dotnet/aspnet:10.0` base image doesn't include `libfontconfig1`, which SkiaSharp's native library depends on. After 10 consecutive emoji failures, the service threw `InvalidOperationException` and the import was marked `Failed`.