### PR TITLE
fix: use IsHoisted for member sidebar role grouping

### DIFF
--- a/apps/api/Codec.Api.Tests/Controllers/ServersControllerTests.cs
+++ b/apps/api/Codec.Api.Tests/Controllers/ServersControllerTests.cs
@@ -3066,6 +3066,107 @@ public class ServersControllerTests : IDisposable
     // ═══════════════════ GetMembers ═══════════════════
 
     [Fact]
+    public async Task GetMembers_DisplayRole_UsesHighestHoistedRole()
+    {
+        var server = new Server { Name = "S" };
+        _db.Servers.Add(server);
+        var (ownerRole, _, memberRole) = CreateDefaultRoles(server);
+
+        // Add a custom hoisted role at position between admin and member
+        var customRole = new ServerRoleEntity
+        {
+            ServerId = server.Id, Name = "VIP", Color = "#FF0000",
+            Position = 1, IsSystemRole = false, IsHoisted = true
+        };
+        _db.ServerRoles.Add(customRole);
+
+        _db.ServerMembers.Add(new ServerMember { ServerId = server.Id, UserId = _testUser.Id });
+        // Assign only the custom hoisted role and the member role
+        _db.ServerMemberRoles.AddRange(
+            new ServerMemberRole { UserId = _testUser.Id, RoleId = customRole.Id },
+            new ServerMemberRole { UserId = _testUser.Id, RoleId = memberRole.Id }
+        );
+        await _db.SaveChangesAsync();
+
+        _userService.Setup(u => u.EnsureMemberAsync(server.Id, _testUser.Id, false))
+            .ReturnsAsync(new ServerMember { ServerId = server.Id, UserId = _testUser.Id });
+
+        var result = await _controller.GetMembers(server.Id);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var members = ok.Value.Should().BeAssignableTo<IEnumerable<object>>().Subject.ToList();
+        members.Should().HaveCount(1);
+
+        // DisplayRole should be the hoisted custom role, not null
+        var json = System.Text.Json.JsonSerializer.Serialize(members[0]);
+        json.Should().Contain("VIP");
+    }
+
+    [Fact]
+    public async Task GetMembers_NoHoistedRole_DisplayRoleIsNull()
+    {
+        var server = new Server { Name = "S" };
+        _db.Servers.Add(server);
+        var (_, _, memberRole) = CreateDefaultRoles(server);
+
+        // Add a non-hoisted custom role
+        var customRole = new ServerRoleEntity
+        {
+            ServerId = server.Id, Name = "Lurker",
+            Position = 1, IsSystemRole = false, IsHoisted = false
+        };
+        _db.ServerRoles.Add(customRole);
+
+        _db.ServerMembers.Add(new ServerMember { ServerId = server.Id, UserId = _testUser.Id });
+        _db.ServerMemberRoles.AddRange(
+            new ServerMemberRole { UserId = _testUser.Id, RoleId = customRole.Id },
+            new ServerMemberRole { UserId = _testUser.Id, RoleId = memberRole.Id }
+        );
+        await _db.SaveChangesAsync();
+
+        _userService.Setup(u => u.EnsureMemberAsync(server.Id, _testUser.Id, false))
+            .ReturnsAsync(new ServerMember { ServerId = server.Id, UserId = _testUser.Id });
+
+        var result = await _controller.GetMembers(server.Id);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var members = ok.Value.Should().BeAssignableTo<IEnumerable<object>>().Subject.ToList();
+        members.Should().HaveCount(1);
+
+        // DisplayRole should be null since no roles are hoisted (Member is not hoisted)
+        var json = System.Text.Json.JsonSerializer.Serialize(members[0]);
+        json.Should().Contain("\"DisplayRole\":null");
+    }
+
+    [Fact]
+    public async Task GetMembers_SystemHoistedRole_UsedAsDisplayRole()
+    {
+        var server = new Server { Name = "S" };
+        _db.Servers.Add(server);
+        var (ownerRole, _, memberRole) = CreateDefaultRoles(server);
+
+        _db.ServerMembers.Add(new ServerMember { ServerId = server.Id, UserId = _testUser.Id });
+        // Assign the hoisted system Owner role
+        _db.ServerMemberRoles.AddRange(
+            new ServerMemberRole { UserId = _testUser.Id, RoleId = ownerRole.Id },
+            new ServerMemberRole { UserId = _testUser.Id, RoleId = memberRole.Id }
+        );
+        await _db.SaveChangesAsync();
+
+        _userService.Setup(u => u.EnsureMemberAsync(server.Id, _testUser.Id, false))
+            .ReturnsAsync(new ServerMember { ServerId = server.Id, UserId = _testUser.Id });
+
+        var result = await _controller.GetMembers(server.Id);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var members = ok.Value.Should().BeAssignableTo<IEnumerable<object>>().Subject.ToList();
+
+        // DisplayRole should be Owner (hoisted system role, not filtered out)
+        var json = System.Text.Json.JsonSerializer.Serialize(members[0]);
+        json.Should().Contain("Owner");
+    }
+
+    [Fact]
     public async Task GetMembers_ValidServer_ReturnsMembers()
     {
         var server = new Server { Name = "S" };

--- a/apps/api/Codec.Api/Controllers/ServersController.cs
+++ b/apps/api/Codec.Api/Controllers/ServersController.cs
@@ -371,7 +371,7 @@ public partial class ServersController(CodecDbContext db, IUserService userServi
             var permissions = roles.Count > 0
                 ? roles.Aggregate(Permission.None, (acc, role) => acc | role.Permissions)
                 : Permission.None;
-            var displayRole = roles.FirstOrDefault(r2 => !r2.IsSystemRole);
+            var displayRole = roles.FirstOrDefault(r2 => r2.IsHoisted);
             var highestPosition = roles.Count > 0 ? roles.Min(r2 => r2.Position) : int.MaxValue;
 
             return new


### PR DESCRIPTION
## Summary

- Fixes member sidebar grouping where all users were listed under "Other" instead of their assigned roles.
- The previous fix (PR #177) changed `displayRole` selection from color-based to `!IsSystemRole`, but this excluded the default Owner and Admin roles which are both system roles *and* hoisted (`IsHoisted = true`). Since most users only have system roles, `displayRole` was always null.
- Changed the filter to `r2.IsHoisted`, selecting the highest-ranked hoisted role regardless of whether it's a system role, matching Discord's behavior.

## Type of Change

- [x] Bug fix

## Testing

- [x] API builds (`dotnet build`)
- [x] All 1388 unit tests pass (`dotnet test`)
- [x] 3 new tests added covering hoisted custom roles, non-hoisted roles, and hoisted system roles

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
- [x] Authz/authn impacts reviewed (if applicable)

## Notes for Reviewers

One-line fix in `ServersController.cs:374`. The root cause was that `!r2.IsSystemRole` filtered out Owner and Admin roles even though they have `IsHoisted = true`. The `IsHoisted` property exists specifically to control sidebar grouping visibility.