### PR TITLE
fix: use consistent theme tokens in Discord import UI

### DIFF
--- a/apps/web/src/lib/components/VerificationGate.svelte
+++ b/apps/web/src/lib/components/VerificationGate.svelte
@@ -179,7 +179,7 @@
 	}
 
 	.error {
-		color: var(--status-danger, #f23f43);
+		color: var(--danger);
 		font-size: 14px;
 	}
 </style>

--- a/apps/web/src/lib/components/discord-import/DiscordImportWizard.svelte
+++ b/apps/web/src/lib/components/discord-import/DiscordImportWizard.svelte
@@ -269,7 +269,7 @@
 	}
 
 	.step-dot.completed {
-		background: var(--text-positive, #3ba55d);
+		background: var(--success);
 	}
 
 	.wizard-content {
@@ -278,8 +278,8 @@
 
 	.import-error {
 		padding: 10px 14px;
-		background: rgba(237, 66, 69, 0.1);
-		color: var(--status-danger);
+		background: rgba(var(--danger-rgb), 0.1);
+		color: var(--danger);
 		border-radius: 4px;
 		font-size: 14px;
 		margin-top: 12px;

--- a/apps/web/src/lib/components/discord-import/WizardStepProgress.svelte
+++ b/apps/web/src/lib/components/discord-import/WizardStepProgress.svelte
@@ -64,8 +64,8 @@
 	{:else if isCompleted}
 		<div class="success-icon">
 			<svg width="48" height="48" viewBox="0 0 48 48" fill="none">
-				<circle cx="24" cy="24" r="24" fill="var(--text-positive, #3ba55d)" opacity="0.15" />
-				<path d="M20 25.5l3.5 3.5 5-6" stroke="var(--text-positive, #3ba55d)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+				<circle cx="24" cy="24" r="24" fill="var(--success)" opacity="0.15" />
+				<path d="M20 25.5l3.5 3.5 5-6" stroke="var(--success)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none" />
 			</svg>
 		</div>
 		<h2>Import Complete</h2>
@@ -195,8 +195,8 @@
 
 	.error-msg {
 		padding: 10px 14px;
-		background: rgba(237, 66, 69, 0.1);
-		color: var(--status-danger);
+		background: rgba(var(--danger-rgb), 0.1);
+		color: var(--danger);
 		border-radius: 4px;
 		font-size: 14px;
 		text-align: left;

--- a/apps/web/src/lib/components/server-settings/ServerDiscordImport.svelte
+++ b/apps/web/src/lib/components/server-settings/ServerDiscordImport.svelte
@@ -256,7 +256,7 @@
 
 	.status-card.in-progress { background: var(--bg-secondary); }
 	.status-card.completed { background: var(--bg-secondary); }
-	.status-card.failed { background: rgba(237, 66, 69, 0.1); }
+	.status-card.failed { background: rgba(var(--danger-rgb), 0.1); }
 
 	.progress-stats {
 		display: flex;
@@ -297,7 +297,7 @@
 	}
 
 	.error-msg {
-		color: var(--status-danger);
+		color: var(--danger);
 		font-size: 14px;
 		margin: 8px 0;
 	}
@@ -371,6 +371,7 @@
 		background: var(--bg-secondary);
 		border-radius: 8px;
 		margin-bottom: 24px;
+		color: var(--text-normal);
 	}
 
 	.import-stats {
@@ -455,7 +456,7 @@
 
 	.claimed-badge {
 		font-size: 12px;
-		color: var(--text-positive, #3ba55d);
+		color: var(--success);
 		font-weight: 600;
 	}
 

--- a/apps/web/src/lib/components/settings/DeleteAccountModal.svelte
+++ b/apps/web/src/lib/components/settings/DeleteAccountModal.svelte
@@ -239,7 +239,7 @@
 	}
 
 	.google-verified {
-		color: var(--text-positive, #43b581);
+		color: var(--success);
 		font-size: 14px;
 		margin: 4px 0 0;
 	}


### PR DESCRIPTION
## Summary

- Replaces undefined CSS variables (`--status-danger`, `--text-positive`) with actual design tokens (`--danger`, `--success`) defined in `tokens.css`, so colors render correctly across all four themes.
- Swaps hardcoded `rgba(237, 66, 69, 0.1)` backgrounds with `rgba(var(--danger-rgb), 0.1)` to respect the active theme.
- Adds `color: var(--text-normal)` to the rehosting media status card so the "Messages have been imported..." text is readable on dark themes instead of rendering in browser-default black.
- Also fixes the same stale token references in `VerificationGate` and `DeleteAccountModal` for full consistency.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore

## Testing

- [ ] API builds (`dotnet build`)
- [x] Web builds (`npm run build`)
- [x] Svelte checks (`npx svelte-check`)
- [ ] Manual end-to-end check performed

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
- [x] Authz/authn impacts reviewed (if applicable)

## Screenshots / Recordings (if UI changes)

<!-- CSS-only changes — verify visually on each theme (default, midnight, ember, light) -->

## Notes for Reviewers

The undefined variables `--status-danger` and `--text-positive` were silently falling back to hardcoded hex values (or nothing), which meant colors didn't adapt to themes. All references now use tokens from `tokens.css`.