### PR TITLE
fix: announcement banner contrast and theme-specific styling

### DIFF
--- a/apps/web/src/lib/components/announcements/AnnouncementBanner.svelte
+++ b/apps/web/src/lib/components/announcements/AnnouncementBanner.svelte
@@ -34,11 +34,12 @@
 		align-items: center;
 		gap: 8px;
 		padding: 10px 16px;
-		background: var(--accent, #5865f2);
-		color: white;
+		background: rgba(var(--accent-rgb, 88, 101, 242), 0.15);
+		color: var(--text-normal);
 		font-size: 14px;
 		min-height: 40px;
 		flex-shrink: 0;
+		border-bottom: 1px solid rgba(var(--accent-rgb, 88, 101, 242), 0.3);
 	}
 
 	.banner-content {
@@ -51,16 +52,17 @@
 
 	.info-icon {
 		flex-shrink: 0;
-		opacity: 0.85;
+		color: var(--accent);
 	}
 
 	.banner-title {
 		font-weight: 600;
 		flex-shrink: 0;
+		color: var(--accent);
 	}
 
 	.banner-body {
-		opacity: 0.9;
+		color: var(--text-muted);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -70,8 +72,7 @@
 		flex-shrink: 0;
 		background: none;
 		border: none;
-		color: white;
-		opacity: 0.7;
+		color: var(--text-muted);
 		cursor: pointer;
 		padding: 4px;
 		border-radius: 4px;
@@ -80,7 +81,7 @@
 	}
 
 	.dismiss-btn:hover {
-		opacity: 1;
-		background: rgba(255, 255, 255, 0.15);
+		color: var(--text-normal);
+		background: rgba(var(--accent-rgb, 88, 101, 242), 0.15);
 	}
 </style>

--- a/apps/web/src/lib/components/announcements/AnnouncementBanner.svelte
+++ b/apps/web/src/lib/components/announcements/AnnouncementBanner.svelte
@@ -9,6 +9,7 @@
 </script>
 
 <div class="announcement-banner" role="status">
+	<div class="banner-accent-edge"></div>
 	<div class="banner-content">
 		<svg class="info-icon" width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
 			<path d="M8 1a7 7 0 1 1 0 14A7 7 0 0 1 8 1Zm0 1a6 6 0 1 0 0 12A6 6 0 0 0 8 2Zm-.5 3h1v1h-1V5Zm0 2h1v5h-1V7Z"/>
@@ -34,12 +35,21 @@
 		align-items: center;
 		gap: 8px;
 		padding: 10px 16px;
-		background: rgba(var(--accent-rgb, 88, 101, 242), 0.15);
-		color: var(--text-normal);
+		background: var(--banner-bg);
 		font-size: 14px;
 		min-height: 40px;
 		flex-shrink: 0;
-		border-bottom: 1px solid rgba(var(--accent-rgb, 88, 101, 242), 0.3);
+		border-bottom: 1px solid var(--banner-border);
+		position: relative;
+	}
+
+	.banner-accent-edge {
+		position: absolute;
+		left: 0;
+		top: 0;
+		bottom: 0;
+		width: 3px;
+		background: var(--banner-icon);
 	}
 
 	.banner-content {
@@ -52,17 +62,17 @@
 
 	.info-icon {
 		flex-shrink: 0;
-		color: var(--accent);
+		color: var(--banner-icon);
 	}
 
 	.banner-title {
 		font-weight: 600;
 		flex-shrink: 0;
-		color: var(--accent);
+		color: var(--banner-title);
 	}
 
 	.banner-body {
-		color: var(--text-muted);
+		color: var(--banner-body);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -72,7 +82,7 @@
 		flex-shrink: 0;
 		background: none;
 		border: none;
-		color: var(--text-muted);
+		color: var(--banner-dismiss);
 		cursor: pointer;
 		padding: 4px;
 		border-radius: 4px;
@@ -81,7 +91,7 @@
 	}
 
 	.dismiss-btn:hover {
-		color: var(--text-normal);
-		background: rgba(var(--accent-rgb, 88, 101, 242), 0.15);
+		color: var(--banner-dismiss-hover);
+		background: var(--banner-dismiss-hover-bg);
 	}
 </style>

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -22,6 +22,15 @@
 	--mention-bg: #123A22;
 	--selection-bg: #0F3A22;
 	--input-bg: #06160C;
+
+	--banner-bg: #061A0C;
+	--banner-border: #0D3A1A;
+	--banner-title: #00FF66;
+	--banner-body: #5AC76A;
+	--banner-icon: #00CC52;
+	--banner-dismiss: #3A7A44;
+	--banner-dismiss-hover: #86FF6B;
+	--banner-dismiss-hover-bg: #0D3A1A;
 }
 
 /* ===== Midnight – dark navy/slate palette ===== */
@@ -48,6 +57,15 @@
 	--mention-bg: #1A2845;
 	--selection-bg: #182A48;
 	--input-bg: #141828;
+
+	--banner-bg: #161C36;
+	--banner-border: #263060;
+	--banner-title: #7BA6FF;
+	--banner-body: #9AA3B8;
+	--banner-icon: #5B8DEF;
+	--banner-dismiss: #6B7280;
+	--banner-dismiss-hover: #C8CDD8;
+	--banner-dismiss-hover-bg: #1E2848;
 }
 
 /* ===== Ember – warm amber/orange palette ===== */
@@ -74,6 +92,15 @@
 	--mention-bg: #302415;
 	--selection-bg: #2E2618;
 	--input-bg: #15100A;
+
+	--banner-bg: #1E1508;
+	--banner-border: #4A3820;
+	--banner-title: #F0A030;
+	--banner-body: #BFA880;
+	--banner-icon: #D89020;
+	--banner-dismiss: #7D6D55;
+	--banner-dismiss-hover: #D4C4A8;
+	--banner-dismiss-hover-bg: #2E2215;
 }
 
 /* ===== Light – Apple-inspired light palette ===== */
@@ -100,4 +127,13 @@
 	--mention-bg: #E8F0FE;
 	--selection-bg: #DCE8FC;
 	--input-bg: #F5F5F7;
+
+	--banner-bg: #EDF2FC;
+	--banner-border: #C8D8F0;
+	--banner-title: #0044AA;
+	--banner-body: #3D3D42;
+	--banner-icon: #0055CC;
+	--banner-dismiss: #8E8E93;
+	--banner-dismiss-hover: #1D1D1F;
+	--banner-dismiss-hover-bg: #DCE4F4;
 }

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -23,14 +23,14 @@
 	--selection-bg: #0F3A22;
 	--input-bg: #06160C;
 
-	--banner-bg: #061A0C;
-	--banner-border: #0D3A1A;
-	--banner-title: #00FF66;
-	--banner-body: #5AC76A;
-	--banner-icon: #00CC52;
-	--banner-dismiss: #3A7A44;
-	--banner-dismiss-hover: #86FF6B;
-	--banner-dismiss-hover-bg: #0D3A1A;
+	--banner-bg: #06160C;              /* input_bg */
+	--banner-border: #1E3A26;          /* border */
+	--banner-title: #00FF66;           /* accent */
+	--banner-body: #3ED44E;            /* text_muted */
+	--banner-icon: #00FF66;            /* accent */
+	--banner-dismiss: #2D7A3A;         /* text_dim */
+	--banner-dismiss-hover: #86FF6B;   /* text_normal */
+	--banner-dismiss-hover-bg: #123A22;/* mention_bg */
 }
 
 /* ===== Midnight – dark navy/slate palette ===== */
@@ -58,14 +58,14 @@
 	--selection-bg: #182A48;
 	--input-bg: #141828;
 
-	--banner-bg: #161C36;
-	--banner-border: #263060;
-	--banner-title: #7BA6FF;
-	--banner-body: #9AA3B8;
-	--banner-icon: #5B8DEF;
-	--banner-dismiss: #6B7280;
-	--banner-dismiss-hover: #C8CDD8;
-	--banner-dismiss-hover-bg: #1E2848;
+	--banner-bg: #171B2E;              /* bg_secondary */
+	--banner-border: #2A3045;          /* border */
+	--banner-title: #7BA6FF;           /* accent_hover */
+	--banner-body: #8B919C;            /* text_muted */
+	--banner-icon: #5B8DEF;            /* accent */
+	--banner-dismiss: #6B7280;         /* text_dim */
+	--banner-dismiss-hover: #C8CDD8;   /* text_normal */
+	--banner-dismiss-hover-bg: #1A2845;/* mention_bg */
 }
 
 /* ===== Ember – warm amber/orange palette ===== */
@@ -93,14 +93,14 @@
 	--selection-bg: #2E2618;
 	--input-bg: #15100A;
 
-	--banner-bg: #1E1508;
-	--banner-border: #4A3820;
-	--banner-title: #F0A030;
-	--banner-body: #BFA880;
-	--banner-icon: #D89020;
-	--banner-dismiss: #7D6D55;
-	--banner-dismiss-hover: #D4C4A8;
-	--banner-dismiss-hover-bg: #2E2215;
+	--banner-bg: #18120C;              /* bg_secondary */
+	--banner-border: #3A2E20;          /* border */
+	--banner-title: #F0A030;           /* accent */
+	--banner-body: #9A8A70;            /* text_muted */
+	--banner-icon: #F0A030;            /* accent */
+	--banner-dismiss: #7D6D55;         /* text_dim */
+	--banner-dismiss-hover: #D4C4A8;   /* text_normal */
+	--banner-dismiss-hover-bg: #302415;/* mention_bg */
 }
 
 /* ===== Light – Apple-inspired light palette ===== */
@@ -128,12 +128,12 @@
 	--selection-bg: #DCE8FC;
 	--input-bg: #F5F5F7;
 
-	--banner-bg: #EDF2FC;
-	--banner-border: #C8D8F0;
-	--banner-title: #0044AA;
-	--banner-body: #3D3D42;
-	--banner-icon: #0055CC;
-	--banner-dismiss: #8E8E93;
-	--banner-dismiss-hover: #1D1D1F;
-	--banner-dismiss-hover-bg: #DCE4F4;
+	--banner-bg: #E8F0FE;              /* mention_bg */
+	--banner-border: #D2D2D7;          /* border */
+	--banner-title: #0055CC;           /* accent */
+	--banner-body: #1D1D1F;            /* text_normal */
+	--banner-icon: #0055CC;            /* accent */
+	--banner-dismiss: #6E6E73;         /* text_muted */
+	--banner-dismiss-hover: #1D1D1F;   /* text_normal */
+	--banner-dismiss-hover-bg: #DCE8FC;/* selection_bg */
 }


### PR DESCRIPTION
## Summary

- The announcement banner used `background: var(--accent)` with hardcoded `color: white`, making text unreadable in themes with bright accent colors (Phosphor green `#00FF66`, Ember orange `#F0A030`).
- Replaced with per-theme `--banner-*` design tokens. Every banner color is an exact alias of an existing palette token (documented with inline comments), so the banner integrates naturally with each theme. All text/icon colors pass WCAG AA contrast minimums against their banner background.
- Added a left accent-edge bar for visual distinction.

## Type of Change

- [x] Bug fix

## Testing

- [x] Web builds (`npm run build`)
- [x] Svelte checks (`npx svelte-check`)

## Security Checklist

- [x] No secrets or credentials added to source control
- [x] Input handling/validation considered for new endpoints
- [x] Authz/authn impacts reviewed (if applicable)

## Notes for Reviewers

WCAG contrast ratios verified programmatically for all 4 themes × 5 text roles. Lowest ratio is Phosphor dismiss at 3.51:1 (AA-large, minimum 3.0). All title/body text exceeds 4.5:1 (AA normal text).